### PR TITLE
feat: add footer component and adjust layout structure #51

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { UserProvider } from "@/contexts/UserContext";
 import { ThemeProvider } from "@/contexts/ThemeContext";
+import Footer from "@/components/Footer";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -31,7 +32,10 @@ export default function RootLayout({
       >
         <ThemeProvider>
           <UserProvider>
-            {children}
+            <div className="flex flex-col min-h-screen">
+              {children}
+              <Footer />
+            </div>
           </UserProvider>
         </ThemeProvider>
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 export default function Home() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
+    <div className="flex-1 bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
       <div className="container mx-auto px-4 py-16">
         <div className="text-center">
           <h1 className="text-6xl font-bold text-gray-900 dark:text-white mb-6">
@@ -12,10 +12,10 @@ export default function Home() {
             Amateur Radio Logging Software
           </p>
           <p className="text-lg text-gray-500 dark:text-gray-400 mb-12 max-w-2xl mx-auto">
-            Log your amateur radio contacts from anywhere. Built with Next.js and MongoDB 
-            for modern, reliable amateur radio logging.
+            Log your amateur radio contacts from anywhere. Built with Next.js
+            and MongoDB for modern, reliable amateur radio logging.
           </p>
-          
+
           <div className="flex gap-4 justify-center">
             <Link
               href="/login"
@@ -31,32 +31,35 @@ export default function Home() {
             </Link>
           </div>
         </div>
-        
+
         <div className="mt-16 grid md:grid-cols-3 gap-8">
           <div className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-lg">
             <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">
               Contact Logging
             </h3>
             <p className="text-gray-600 dark:text-gray-300">
-              Log your amateur radio contacts with detailed information including frequency, mode, RST, and QSL status.
+              Log your amateur radio contacts with detailed information
+              including frequency, mode, RST, and QSL status.
             </p>
           </div>
-          
+
           <div className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-lg">
             <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">
               Search & Filter
             </h3>
             <p className="text-gray-600 dark:text-gray-300">
-              Quickly find contacts using powerful search and filtering options by callsign, date, band, and more.
+              Quickly find contacts using powerful search and filtering options
+              by callsign, date, band, and more.
             </p>
           </div>
-          
+
           <div className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-lg">
             <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">
               Export Data
             </h3>
             <p className="text-gray-600 dark:text-gray-300">
-              Export your logbook data in various formats including ADIF for use with other amateur radio software.
+              Export your logbook data in various formats including ADIF for use
+              with other amateur radio software.
             </p>
           </div>
         </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import Link from "next/link";
+import { Github, Radio } from "lucide-react";
+
+export default function Footer() {
+  return (
+    <footer className="bg-card border-t py-4 mt-auto">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex flex-col md:flex-row justify-between items-center gap-4">
+          <div className="flex flex-col space-y-1">
+            <div className="flex items-center space-x-2">
+              <Radio className="h-4 w-4 text-primary" />
+              <span className="text-sm font-medium">Nextlog</span>
+            </div>
+            <span className="text-xs text-muted-foreground">
+              © {new Date().getFullYear()} Amateur Radio Logging Software
+            </span>
+          </div>
+
+          <div className="flex items-center space-x-6">
+            <Link
+              href="https://github.com/ks3ckc/nodelog"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-muted-foreground hover:text-primary flex items-center"
+            >
+              <Github className="h-4 w-4 mr-1" />
+              <span>GitHub Repository</span>
+            </Link>
+
+            <Link
+              href="https://ks3ckc.radio"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-muted-foreground hover:text-primary flex items-center"
+            >
+              <Radio className="h-4 w-4 mr-1" />
+              <span>ks3ckc.radio</span>
+            </Link>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -20,7 +20,7 @@ export default function Footer() {
 
           <div className="flex items-center space-x-6">
             <Link
-              href="https://github.com/ks3ckc/nodelog"
+              href="https://github.com/patrickrb/nextlog"
               target="_blank"
               rel="noopener noreferrer"
               className="text-sm text-muted-foreground hover:text-primary flex items-center"


### PR DESCRIPTION
This PR addresses #51, adds a consistent footer across the app with links to the GitHub repo, [ks3ckc.radio](https://ks3ckc.radio/) site. Layout updates keep it fixed at the bottom of the page.

## Changes
- Added a new Footer component with links to GitHub repository and project website
- Integrated the Footer component into the RootLayout for consistent display across all pages
- Updated layout structure with proper flex container to ensure footer stays at the bottom
- Improved Home page layout with better text formatting and responsive design

## Testing
- Verified footer displays correctly on all pages in both light and dark modes
- Confirmed responsive behavior on mobile, tablet, and desktop screen sizes
- Checked that all links in the footer work correctly

Closes #51.