### PR TITLE
chore(logging): strip debug console.log noise + enforce no-console lint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,12 +9,20 @@ const eslintConfig = [
       "react-hooks/set-state-in-effect": "warn",
       "react-hooks/immutability": "warn",
       "react-hooks/preserve-manual-memoization": "warn",
+      "no-console": ["error", { allow: ["warn", "error"] }],
     },
   },
   {
-    files: ["scripts/**/*.js"],
+    files: ["scripts/**/*.{js,mjs}"],
     rules: {
       "@typescript-eslint/no-require-imports": "off",
+      "no-console": "off",
+    },
+  },
+  {
+    files: ["tests/**/*.{ts,js}"],
+    rules: {
+      "no-console": "off",
     },
   },
 ];

--- a/src/app/api/adif/import/route.ts
+++ b/src/app/api/adif/import/route.ts
@@ -114,9 +114,7 @@ async function parseAndImportADIF(content: string, userId: number, stationId: nu
 
     // Parse records
     const records = parseADIFRecords(dataContent);
-    console.log(`Parsed ${records.length} records from ADIF file`);
-    console.log(`First record sample:`, records[0]?.fields ? Object.keys(records[0].fields).slice(0, 5) : 'No records');
-    
+
     // Limit number of records for large imports using dynamic setting
     if (records.length > maxRecords) {
       return {
@@ -153,18 +151,10 @@ async function parseAndImportADIF(content: string, userId: number, stationId: nu
       const startIdx = batchIndex * batchSize;
       const endIdx = Math.min(startIdx + batchSize, records.length);
       const batch = records.slice(startIdx, endIdx);
-      
-      console.log(`Processing batch ${batchIndex + 1}/${totalBatches} (${batch.length} records) - ${elapsedTime/1000}s elapsed`);
-      console.log(`Current results so far: ${result.imported} imported, ${result.skipped} skipped, ${result.errors} errors`);
-      
+
       try {
         // Process batch with transaction for better performance
         await processBatch(batch, userId, stationId, result);
-        
-        // Log progress every 10 batches
-        if ((batchIndex + 1) % 10 === 0) {
-          console.log(`Progress: ${batchIndex + 1}/${totalBatches} batches completed. ${result.imported} imported, ${result.skipped} skipped, ${result.errors} errors.`);
-        }
       } catch (batchError) {
         console.error(`Batch ${batchIndex + 1} failed:`, batchError);
         result.errors += batch.length; // Mark all records in batch as errors
@@ -209,30 +199,21 @@ async function parseAndImportADIF(content: string, userId: number, stationId: nu
 }
 
 async function processBatch(records: ADIFRecord[], userId: number, stationId: number, result: ImportResult): Promise<void> {
-  console.log(`Starting batch of ${records.length} records...`);
-  
   for (let i = 0; i < records.length; i++) {
     const record = records[i];
     try {
       await importRecord(record, userId, stationId, result);
-      
-      // Log progress every 10 records within batch
-      if ((i + 1) % 10 === 0) {
-        console.log(`  Processed ${i + 1}/${records.length} records in current batch`);
-      }
     } catch (error) {
       result.errors++;
       const errorMsg = error instanceof Error ? error.message : 'Unknown error';
       console.error(`Record ${i + 1} import error:`, errorMsg);
-      
+
       // Only store first 10 error details to avoid memory issues
       if (result.details && result.details.length < 10) {
         result.details.push(`Error importing record ${i + 1}: ${errorMsg}`);
       }
     }
   }
-  
-  console.log(`Batch completed: ${result.imported} total imported, ${result.skipped} total skipped, ${result.errors} total errors`);
 }
 
 function parseADIFRecords(content: string): ADIFRecord[] {

--- a/src/app/api/contacts/qrz-download/route.ts
+++ b/src/app/api/contacts/qrz-download/route.ts
@@ -39,17 +39,12 @@ export async function POST(request: NextRequest) {
       }, { status: 400 });
     }
 
-    console.log(`Starting QRZ download for ${stationsWithKeys.length} stations`);
-
     for (const station of stationsWithKeys) {
       try {
-        console.log(`Processing station: ${station.callsign} (${station.station_name})`);
-        
         // Download QSOs from QRZ for this station
         const downloadResult = await downloadQSOsFromQRZ(station.qrz_api_key!, since);
-        
+
         if (!downloadResult.success) {
-          console.log(`QRZ download failed for station ${station.callsign}: ${downloadResult.error}`);
           results.push({
             stationId: station.id,
             stationCallsign: station.callsign,
@@ -59,14 +54,10 @@ export async function POST(request: NextRequest) {
           continue;
         }
 
-        console.log(`Downloaded ${downloadResult.qsos.length} QSOs from QRZ for station ${station.callsign}`);
-        
         // Get contacts for this station that were sent to QRZ but not confirmed
         const unconfirmedContacts = await Contact.findQrzSentNotConfirmed(decoded.userId);
         const stationContacts = unconfirmedContacts.filter(c => c.station_id === station.id);
-        
-        console.log(`Found ${stationContacts.length} unconfirmed contacts for station ${station.callsign}`);
-        
+
         let confirmationsFound = 0;
 
         // Annotate each contact with the station callsign so the matcher can
@@ -93,7 +84,6 @@ export async function POST(request: NextRequest) {
               break;
             }
 
-            console.log(`Marking ${contact.callsign} as QRZ confirmed (status=${qrzQSO.app_qrzlog_status ?? '<missing>'})`);
             await Contact.updateQrzQsl(contact.id, undefined, 'Y');
             confirmationsFound++;
 
@@ -122,8 +112,6 @@ export async function POST(request: NextRequest) {
         
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-        console.log(`Exception processing station ${station.callsign}: ${errorMessage}`);
-        
         results.push({
           stationId: station.id,
           stationCallsign: station.callsign,
@@ -132,8 +120,6 @@ export async function POST(request: NextRequest) {
         });
       }
     }
-
-    console.log(`QRZ download completed. Processed ${stationsProcessed.size} stations`);
 
     // Calculate summary
     const successful = results.filter(r => r.success).length;

--- a/src/app/api/contacts/qrz-sync/route.ts
+++ b/src/app/api/contacts/qrz-sync/route.ts
@@ -29,17 +29,12 @@ export async function POST(request: NextRequest) {
 
     const results = [];
 
-    console.log(`Starting QRZ upload for ${contactIds.length} contacts`);
-    
     // Process each contact
     for (const contactId of contactIds) {
       try {
-        console.log(`Processing contact ID: ${contactId}`);
-        
         // Get the contact
         const contact = await Contact.findById(contactId);
         if (!contact || contact.user_id !== decoded.userId) {
-          console.log(`Contact ${contactId}: Not found or access denied`);
           results.push({
             contactId,
             success: false,
@@ -48,12 +43,8 @@ export async function POST(request: NextRequest) {
           continue;
         }
 
-        console.log(`Contact ${contactId}: Found contact for ${contact.callsign} on ${contact.datetime}`);
-      
-
         // Skip if already sent to QRZ
         if (contact.qrz_qsl_sent === 'Y') {
-          console.log(`Contact ${contactId}: Already sent to QRZ, skipping`);
           results.push({
             contactId,
             success: true,
@@ -65,7 +56,6 @@ export async function POST(request: NextRequest) {
 
         // If we've received confirmation from QRZ, mark as sent too (it exists in QRZ)
         if (contact.qrz_qsl_rcvd === 'Y') {
-          console.log(`Contact ${contactId}: Already confirmed by QRZ - marking as sent in our database`);
           await Contact.updateQrzQsl(contactId, 'Y');
           results.push({
             contactId,
@@ -78,7 +68,6 @@ export async function POST(request: NextRequest) {
 
         // Get the station for this contact to get QRZ API key
         if (!contact.station_id) {
-          console.log(`Contact ${contactId}: No station_id associated`);
           results.push({
             contactId,
             success: false,
@@ -87,10 +76,8 @@ export async function POST(request: NextRequest) {
           continue;
         }
 
-        console.log(`Contact ${contactId}: Looking up station ID ${contact.station_id}`);
         const station = await Station.findByUserIdAndId(decoded.userId, contact.station_id);
         if (!station) {
-          console.log(`Contact ${contactId}: Station ${contact.station_id} not found`);
           results.push({
             contactId,
             success: false,
@@ -99,10 +86,7 @@ export async function POST(request: NextRequest) {
           continue;
         }
 
-        console.log(`Contact ${contactId}: Found station ${station.callsign} (${station.station_name})`);
-        
         if (!station.qrz_api_key) {
-          console.log(`Contact ${contactId}: Station ${station.callsign} has no QRZ API key`);
           results.push({
             contactId,
             success: false,
@@ -111,32 +95,14 @@ export async function POST(request: NextRequest) {
           continue;
         }
 
-        console.log(`Contact ${contactId}: Station has QRZ API key, proceeding with sync`);
-      
-
-        // Convert contact to QRZ format
-        console.log(`Contact ${contactId}: Converting to QRZ format`);
+        // Convert contact to QRZ format and upload
         const qrzData = contactToQRZFormat(contact);
-        console.log(`Contact ${contactId}: QRZ data:`, { 
-          call: qrzData.call, 
-          qso_date: qrzData.qso_date, 
-          time_on: qrzData.time_on, 
-          band: qrzData.band, 
-          mode: qrzData.mode 
-        });
-
-        // Upload to QRZ using API key
-        console.log(`Contact ${contactId}: Uploading to QRZ with API key`);
         const uploadResult = await uploadQSOToQRZWithApiKey(qrzData, station.qrz_api_key);
-        console.log(`Contact ${contactId}: QRZ upload result:`, uploadResult);
 
         if (uploadResult.success) {
           if (uploadResult.already_exists) {
-            console.log(`Contact ${contactId}: QSO already exists in QRZ - marking as both sent and received in our database`);
             // Mark as both sent AND received since it exists in QRZ (it's confirmed!)
-            const updateResult = await Contact.updateQrzQsl(contactId, 'Y', 'Y');
-            console.log(`Contact ${contactId}: Database update result:`, updateResult ? 'success' : 'failed');
-            
+            await Contact.updateQrzQsl(contactId, 'Y', 'Y');
             results.push({
               contactId,
               success: true,
@@ -144,11 +110,8 @@ export async function POST(request: NextRequest) {
               message: 'QSO already exists in QRZ logbook (marked as sent and confirmed)'
             });
           } else {
-            console.log(`Contact ${contactId}: QRZ upload successful - marking as sent in our database`);
             // Mark as sent to QRZ (but not yet confirmed)
-            const updateResult = await Contact.updateQrzQsl(contactId, 'Y');
-            console.log(`Contact ${contactId}: Database update result:`, updateResult ? 'success' : 'failed');
-            
+            await Contact.updateQrzQsl(contactId, 'Y');
             results.push({
               contactId,
               success: true,
@@ -156,10 +119,8 @@ export async function POST(request: NextRequest) {
             });
           }
         } else {
-          console.log(`Contact ${contactId}: QRZ upload failed: ${uploadResult.error}`);
           // Mark as request failed
           await Contact.updateQrzQsl(contactId, 'R');
-          
           results.push({
             contactId,
             success: false,
@@ -170,9 +131,7 @@ export async function POST(request: NextRequest) {
       } catch (error) {
         // Mark as error
         const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-        console.log(`Contact ${contactId}: Exception occurred: ${errorMessage}`);
         await Contact.updateQrzQsl(contactId, 'R');
-        
         results.push({
           contactId,
           success: false,
@@ -180,13 +139,6 @@ export async function POST(request: NextRequest) {
         });
       }
     }
-
-    console.log(`QRZ upload completed. Processing summary:`);
-    console.log(`- Total contacts: ${contactIds.length}`);
-    console.log(`- Successfully sent: ${results.filter(r => r.success).length}`);
-    console.log(`- Failed: ${results.filter(r => !r.success).length}`);
-    console.log(`- Skipped: ${results.filter(r => r.skipped).length}`);
-    console.log(`- Already existed: ${results.filter(r => r.already_existed).length}`);
 
     // Calculate summary
     const successful = results.filter(r => r.success).length;
@@ -207,8 +159,8 @@ export async function POST(request: NextRequest) {
 
   } catch (error) {
     console.error('QRZ sync error:', error);
-    return NextResponse.json({ 
-      error: 'Failed to sync with QRZ' 
+    return NextResponse.json({
+      error: 'Failed to sync with QRZ'
     }, { status: 500 });
   }
 }

--- a/src/app/api/cron/lotw-download/route.ts
+++ b/src/app/api/cron/lotw-download/route.ts
@@ -6,17 +6,6 @@ import { query } from '@/lib/db';
 
 export async function GET(request: NextRequest) {
   try {
-    // Enhanced error logging for troubleshooting
-    console.log('LoTW download cron job authentication check...');
-    console.log('Request headers (excluding sensitive data):', {
-      'user-agent': request.headers.get('user-agent'),
-      'x-vercel-id': request.headers.get('x-vercel-id'),
-      'x-forwarded-for': request.headers.get('x-forwarded-for'),
-      'host': request.headers.get('host'),
-      'has-authorization': !!request.headers.get('authorization'),
-      'cron-secret-configured': !!process.env.CRON_SECRET
-    });
-
     // Environment validation
     const requiredEnvVars = ['DATABASE_URL', 'JWT_SECRET', 'ENCRYPTION_SECRET'];
     const missingEnvVars = requiredEnvVars.filter(varName => !process.env[varName]);
@@ -48,8 +37,6 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    console.log('Starting LoTW download cron job...');
-    
     // Get all active stations that have LoTW credentials configured
     const stationsResult = await query(`
       SELECT DISTINCT s.id, s.callsign, s.user_id
@@ -77,7 +64,6 @@ export async function GET(request: NextRequest) {
         );
 
         if (recentDownloadResult.rows.length > 0) {
-          console.log(`Skipping station ${station.callsign} - downloaded recently`);
           results.push({
             station_id: station.id,
             callsign: station.callsign,
@@ -121,8 +107,6 @@ export async function GET(request: NextRequest) {
           error: downloadResponse.ok ? null : downloadData.error
         });
 
-        console.log(`Station ${station.callsign}: ${downloadResponse.ok ? 'success' : 'error'} - ${downloadData.confirmations_found || 0} confirmations found, ${downloadData.confirmations_matched || 0} matched`);
-
       } catch (stationError) {
         console.error(`Error processing station ${station.callsign}:`, stationError);
         results.push({
@@ -133,8 +117,6 @@ export async function GET(request: NextRequest) {
         });
       }
     }
-
-    console.log('LoTW download cron job completed');
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/cron/lotw-upload/route.ts
+++ b/src/app/api/cron/lotw-upload/route.ts
@@ -6,17 +6,6 @@ import { query } from '@/lib/db';
 
 export async function GET(request: NextRequest) {
   try {
-    // Enhanced error logging for troubleshooting
-    console.log('LoTW upload cron job authentication check...');
-    console.log('Request headers (excluding sensitive data):', {
-      'user-agent': request.headers.get('user-agent'),
-      'x-vercel-id': request.headers.get('x-vercel-id'),
-      'x-forwarded-for': request.headers.get('x-forwarded-for'),
-      'host': request.headers.get('host'),
-      'has-authorization': !!request.headers.get('authorization'),
-      'cron-secret-configured': !!process.env.CRON_SECRET
-    });
-
     // Environment validation
     const requiredEnvVars = ['DATABASE_URL', 'JWT_SECRET', 'ENCRYPTION_SECRET'];
     const missingEnvVars = requiredEnvVars.filter(varName => !process.env[varName]);
@@ -48,8 +37,6 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    console.log('Starting LoTW upload cron job...');
-    
     // Check if lotw_credentials table exists before proceeding
     const tableCheckResult = await query(`
       SELECT table_name 
@@ -58,7 +45,6 @@ export async function GET(request: NextRequest) {
     `);
     
     if (tableCheckResult.rows.length === 0) {
-      console.log('lotw_credentials table does not exist, skipping LoTW upload cron job');
       return NextResponse.json({
         success: true,
         message: 'LoTW upload skipped - lotw_credentials table not found',
@@ -106,7 +92,6 @@ export async function GET(request: NextRequest) {
           );
 
           if (recentUploadResult.rows.length > 0) {
-            console.log(`Skipping station ${station.callsign} - uploaded recently`);
             results.push({
               station_id: station.id,
               callsign: station.callsign,
@@ -150,8 +135,6 @@ export async function GET(request: NextRequest) {
           error: uploadResponse.ok ? null : uploadData.error
         });
 
-        console.log(`Station ${station.callsign}: ${uploadResponse.ok ? 'success' : 'error'} - ${uploadData.qso_count || 0} QSOs`);
-
       } catch (stationError) {
         console.error(`Error processing station ${station.callsign}:`, stationError);
         results.push({
@@ -162,8 +145,6 @@ export async function GET(request: NextRequest) {
         });
       }
     }
-
-    console.log('LoTW upload cron job completed');
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/dxpeditions/route.ts
+++ b/src/app/api/dxpeditions/route.ts
@@ -178,7 +178,6 @@ async function fetchDXpeditionData(): Promise<DXpedition[]> {
     console.error('Error fetching DXpedition data:', error);
     // Return cached data if available, even if stale
     if (cachedData) {
-      console.log('Using stale cache due to fetch error');
       return cachedData;
     }
     return [];

--- a/src/app/api/install/finalize/route.ts
+++ b/src/app/api/install/finalize/route.ts
@@ -31,13 +31,7 @@ export async function POST() {
       const statesCount = parseInt(statesResult.rows[0].count);
       
       const tableNames = tableListResult.rows.map(row => row.table_name);
-      
-      console.log('Installation verification:');
-      console.log(`Tables found (${tableCount}):`, tableNames);
-      console.log(`Admin users: ${adminCount}`);
-      console.log(`DXCC entities: ${dxccCount}`);
-      console.log(`States/provinces: ${statesCount}`);
-      
+
       // Expected tables
       const expectedTables = [
         'users', 'stations', 'contacts', 'dxcc_entities', 'states_provinces',
@@ -48,8 +42,7 @@ export async function POST() {
       const missingTables = expectedTables.filter(table => !tableNames.includes(table));
       
       if (missingTables.length > 0) {
-        console.log('Missing tables:', missingTables);
-        // Don't fail the installation for missing tables, just log them
+        // Don't fail the installation for missing tables, just warn
         console.warn(`Some optional tables are missing: ${missingTables.join(', ')}`);
       }
       
@@ -80,8 +73,6 @@ export async function POST() {
           VALUES ('local_storage', true, NOW())
           ON CONFLICT (config_type) DO NOTHING
         `);
-      } else {
-        console.log('storage_config table not found, skipping installation marker');
       }
       
       return NextResponse.json({ 

--- a/src/app/api/install/migrate-schema/route.ts
+++ b/src/app/api/install/migrate-schema/route.ts
@@ -3,8 +3,6 @@ import db from '@/lib/db';
 
 export async function POST() {
   try {
-    console.log('Starting schema migration...');
-    
     // Check what columns exist and add missing ones
     const contactsColumns = await db.query(`
       SELECT column_name 
@@ -256,12 +254,9 @@ export async function POST() {
       migrations.push('CREATE INDEX IF NOT EXISTS idx_qsl_images_created_at ON qsl_images(created_at DESC)');
     }
     
-    console.log(`Running ${migrations.length} migrations...`);
-    
     // Execute migrations
     for (const migration of migrations) {
       try {
-        console.log('Executing:', migration);
         await db.query(migration);
       } catch (error) {
         console.warn('Migration failed (may already exist):', migration, error);
@@ -285,9 +280,7 @@ export async function POST() {
       }
     }
     
-    console.log('Schema migration completed successfully');
-    
-    return NextResponse.json({ 
+    return NextResponse.json({
       success: true,
       message: 'Schema migration completed',
       migrationsExecuted: migrations.length

--- a/src/app/api/lotw/download-contact/route.ts
+++ b/src/app/api/lotw/download-contact/route.ts
@@ -60,20 +60,15 @@ export async function POST(request: NextRequest) {
     let lotwPassword = contact.lotw_password;
     let credentialSource = 'none';
 
-    console.log(`[LoTW Download] Checking credentials for contact ${contact_id}, station ${contact.station_id} (${contact.station_callsign})`);
-    console.log(`[LoTW Download] Station credentials present: username=${!!lotwUsername}, password=${!!lotwPassword}`);
-
     // Try user's third_party_services if station doesn't have credentials
     if (!lotwUsername || !lotwPassword) {
       const thirdPartyServices = contact.third_party_services;
-      console.log(`[LoTW Download] Checking user-level credentials: third_party_services=${!!thirdPartyServices}, lotw field=${!!thirdPartyServices?.lotw}`);
 
       if (thirdPartyServices?.lotw) {
         lotwUsername = thirdPartyServices.lotw.username;
         try {
           lotwPassword = decryptString(thirdPartyServices.lotw.password);
           credentialSource = 'user';
-          console.log(`[LoTW Download] Using user-level credentials, username present: ${!!lotwUsername}`);
         } catch (error) {
           console.error('[LoTW Download] Failed to decrypt user password:', error);
           lotwPassword = undefined;
@@ -84,7 +79,6 @@ export async function POST(request: NextRequest) {
       try {
         lotwPassword = decryptString(lotwPassword);
         credentialSource = 'station';
-        console.log(`[LoTW Download] Using station-level credentials for station ${contact.station_id}`);
       } catch (error) {
         console.error('[LoTW Download] Failed to decrypt station password:', error);
         lotwPassword = undefined;
@@ -109,8 +103,6 @@ export async function POST(request: NextRequest) {
         }
       }, { status: 400 });
     }
-
-    console.log(`[LoTW Download] Credentials validated from source: ${credentialSource}`);
 
     // Create a date range around the contact (±1 day to be safe)
     const contactDate = new Date(contact.datetime);

--- a/src/app/api/lotw/download/route.ts
+++ b/src/app/api/lotw/download/route.ts
@@ -72,20 +72,15 @@ export async function POST(request: NextRequest) {
     let lotwPassword = station.lotw_password;
     let credentialSource = 'none';
 
-    console.log(`[LoTW Download] Checking credentials for station ${station_id} (${station.callsign})`);
-    console.log(`[LoTW Download] Station credentials present: username=${!!lotwUsername}, password=${!!lotwPassword}`);
-
     // Try user's third_party_services if station doesn't have credentials
     if (!lotwUsername || !lotwPassword) {
       const thirdPartyServices = station.third_party_services;
-      console.log(`[LoTW Download] Checking user-level credentials: third_party_services=${!!thirdPartyServices}, lotw field=${!!thirdPartyServices?.lotw}`);
 
       if (thirdPartyServices?.lotw) {
         lotwUsername = thirdPartyServices.lotw.username;
         try {
           lotwPassword = decryptString(thirdPartyServices.lotw.password);
           credentialSource = 'user';
-          console.log(`[LoTW Download] Using user-level credentials, username present: ${!!lotwUsername}`);
         } catch (error) {
           console.error('[LoTW Download] Failed to decrypt user password:', error);
           lotwPassword = undefined;
@@ -96,7 +91,6 @@ export async function POST(request: NextRequest) {
       try {
         lotwPassword = decryptString(lotwPassword);
         credentialSource = 'station';
-        console.log(`[LoTW Download] Using station-level credentials for station ${station_id}`);
       } catch (error) {
         console.error('[LoTW Download] Failed to decrypt station password:', error);
         lotwPassword = undefined;
@@ -121,8 +115,6 @@ export async function POST(request: NextRequest) {
         }
       }, { status: 400 });
     }
-
-    console.log(`[LoTW Download] Credentials validated from source: ${credentialSource}`);
 
     // Create download log entry
     const downloadLogResult = await query(

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -621,10 +621,7 @@ export default function SearchPage() {
         if (skipped > 0) messages.push(`${skipped} contact(s) skipped (already synced)`);
         if (failed > 0) messages.push(`${failed} contact(s) failed to sync`);
         
-        if (messages.length > 0) {
-          // You could add a toast notification here
-          console.log('QRZ Sync Results:', messages.join(', '));
-        }
+        // TODO: surface QRZ sync results via toast notification
       } else {
         setError(data.error || 'Failed to sync contacts to QRZ');
       }

--- a/src/components/AutoImportADIF.tsx
+++ b/src/components/AutoImportADIF.tsx
@@ -137,13 +137,10 @@ export default function AutoImportADIF({ stationId }: { stationId: number }) {
       
       // Parse all records
       const allRecords = parseADIFRecords(content);
-      console.log(`Parsed ${allRecords.length} total records`);
 
       // Determine chunk size (200 records per chunk for reliable Vercel processing)
       const chunkSize = 200;
       const chunks = Math.ceil(allRecords.length / chunkSize);
-
-      console.log(`Splitting into ${chunks} chunks of ${chunkSize} records each`);
 
       // Set initial progress data immediately to ensure progress bar shows
       const startTime = Date.now();
@@ -168,8 +165,6 @@ export default function AutoImportADIF({ stationId }: { stationId: number }) {
         const startIdx = i * chunkSize;
         const endIdx = Math.min(startIdx + chunkSize, allRecords.length);
         const chunkRecords = allRecords.slice(startIdx, endIdx);
-
-        console.log(`Processing chunk ${i + 1}/${chunks} (${chunkRecords.length} records)`);
 
         // Update progress data for current chunk
         const currentProgress = Math.round(((i) / chunks) * 100);
@@ -209,8 +204,6 @@ export default function AutoImportADIF({ stationId }: { stationId: number }) {
           totalSkipped += result.skipped;
           totalErrors += result.errors;
 
-          console.log(`Chunk ${i + 1} completed: ${result.imported} imported, ${result.skipped} skipped, ${result.errors} errors`);
-
           // Delay between chunks to avoid overwhelming the server and allow connections to reset
           if (i < chunks - 1) {
             await new Promise(resolve => setTimeout(resolve, 2000)); // 2 second delay
@@ -238,7 +231,6 @@ export default function AutoImportADIF({ stationId }: { stationId: number }) {
           
           // For timeouts, add extra delay before continuing
           if (isTimeout && i < chunks - 1) {
-            console.log('Adding extra delay after timeout...');
             await new Promise(resolve => setTimeout(resolve, 3000));
           }
         }

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -48,12 +48,10 @@ export function UserProvider({ children }: { children: ReactNode }) {
           const errorText = await response.text();
           if (errorText.includes('relation "users" does not exist') || errorText.includes('42P01')) {
             // Database tables don't exist - this is expected during first install
-            console.log('Database tables not found - installation may be needed');
             setUser(null);
             return;
           }
         } catch {
-          console.log('Could not read error response text');
           setUser(null);
           return;
         }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -15,6 +15,7 @@ export const logger = {
      */
     debug: (message: string, context?: LogContext) => {
         if (process.env.NODE_ENV === 'development') {
+            // eslint-disable-next-line no-console
             console.log(`[DEBUG] ${message}`, context || '');
         }
     },
@@ -24,6 +25,7 @@ export const logger = {
      * Use for general informational messages
      */
     info: (message: string, context?: LogContext) => {
+        // eslint-disable-next-line no-console
         console.log(`[INFO] ${message}`, context || '');
     },
 

--- a/src/lib/qrz.ts
+++ b/src/lib/qrz.ts
@@ -269,13 +269,11 @@ export async function uploadQSOToQRZWithApiKey(
     });
     
     const uploadResult = await uploadResponse.text();
-    console.log('QRZ upload raw response:', uploadResult);
-    
+
     // Parse upload result
     if (uploadResult.includes('FAIL')) {
       // Check for duplicate (case-insensitive)
       if (uploadResult.toLowerCase().includes('duplicate')) {
-        console.log('Detected duplicate QSO in QRZ - treating as success');
         return {
           success: true,  // Changed to true - duplicate means it's in QRZ (success!)
           already_exists: true,
@@ -473,8 +471,6 @@ function formatQSOAsADIF(qso: QRZQSOData): string {
 
 // Function to validate QRZ API key (for logbook operations)
 export async function validateQRZApiKey(apiKey: string): Promise<{valid: boolean; error?: string}> {
-  console.log('Validating QRZ API key (first 8 chars):', apiKey.substring(0, 8) + '...');
-  
   if (!apiKey) {
     return {
       valid: false,
@@ -489,30 +485,25 @@ export async function validateQRZApiKey(apiKey: string): Promise<{valid: boolean
     const testFormData = new FormData();
     testFormData.append('KEY', apiKey);
     testFormData.append('ACTION', 'STATUS');
-    
-    console.log('Making request to QRZ logbook API for API key validation...');
+
     const response = await fetch(sessionUrl, {
       method: 'POST',
       body: testFormData
     });
-    
+
     const result = await response.text();
-    console.log('QRZ API key validation response:', result);
-    
+
     if (result.includes('INVALID_KEY')) {
-      console.log('QRZ API key validation failed - invalid key');
       return {
         valid: false,
         error: 'Invalid QRZ API key'
       };
     }
-    
+
     if (result.includes('OK') || result.includes('STATUS')) {
-      console.log('QRZ API key validation successful');
       return { valid: true };
     }
-    
-    console.log('Unexpected QRZ API response');
+
     return {
       valid: false,
       error: `Unexpected response from QRZ: ${result}`
@@ -532,8 +523,6 @@ export async function downloadQSOsFromQRZ(
   apiKey: string,
   since?: string // YYYY-MM-DD format
 ): Promise<QRZDownloadResult> {
-  console.log('Downloading QSOs from QRZ logbook...');
-  
   if (!apiKey) {
     return {
       success: false,
@@ -559,38 +548,33 @@ export async function downloadQSOsFromQRZ(
     downloadFormData.append('KEY', apiKey);
     downloadFormData.append('ACTION', 'FETCH');
     downloadFormData.append('OPTION', optionParts.join(';'));
-    
-    console.log('Making request to QRZ for QSO download...');
+
     const downloadResponse = await fetch(sessionUrl, {
       method: 'POST',
       body: downloadFormData
     });
-    
+
     const downloadResult = await downloadResponse.text();
-    console.log('QRZ download response received, parsing ADIF...');
-    
+
     if (downloadResult.includes('INVALID_KEY')) {
-      console.log('QRZ download failed - invalid key');
       return {
         success: false,
         qsos: [],
         error: 'Invalid QRZ API key'
       };
     }
-    
+
     if (downloadResult.includes('FAIL')) {
-      console.log('QRZ download failed');
       return {
         success: false,
         qsos: [],
         error: `QRZ download failed: ${downloadResult}`
       };
     }
-    
+
     // Parse ADIF data to extract QSOs
     const qsos = parseADIFForQRZ(downloadResult);
-    console.log(`Successfully parsed ${qsos.length} QSOs from QRZ`);
-    
+
     return {
       success: true,
       qsos
@@ -708,8 +692,6 @@ function parseADIFForQRZ(adifData: string): QRZQSORecord[] {
 
 // Function to validate QRZ logbook credentials (legacy)
 export async function validateQRZCredentials(username: string, password: string): Promise<{valid: boolean; error?: string}> {
-  console.log('Validating QRZ credentials for username:', username);
-  
   try {
     const sessionUrl = `https://logbook.qrz.com/api`;
     
@@ -717,34 +699,29 @@ export async function validateQRZCredentials(username: string, password: string)
     authFormData.append('username', username);
     authFormData.append('password', password);
     authFormData.append('agent', 'Nextlog_1.0');
-    
-    console.log('Making request to QRZ logbook API...');
+
     const response = await fetch(sessionUrl, {
       method: 'POST',
       body: authFormData
     });
-    
+
     const result = await response.text();
-    console.log('QRZ API response:', result);
-    
+
     if (result.includes('AUTH_FAILED') || result.includes('INVALID')) {
-      console.log('QRZ authentication failed');
       return {
         valid: false,
         error: 'Invalid QRZ credentials for logbook access'
       };
     }
-    
+
     const keyMatch = result.match(/KEY=([A-Za-z0-9]+)/);
     if (!keyMatch) {
-      console.log('No session key found in response');
       return {
         valid: false,
         error: 'Unable to authenticate with QRZ logbook API'
       };
     }
-    
-    console.log('QRZ validation successful, session key obtained');
+
     return { valid: true };
     
   } catch (error) {

--- a/tests/database-integration.spec.ts
+++ b/tests/database-integration.spec.ts
@@ -35,7 +35,7 @@ test.describe('Database Integration Tests', () => {
       // Should handle database errors gracefully (not return 500)
       // May return 401, 403, 404, or other non-500 errors
       if (status) {
-        if (status >= 500) {
+        if (status >= 500 && response) {
           console.log(`Endpoint ${endpoint} returned ${status} status`);
           const body = await response.text();
           console.log(`Response body: ${body.substring(0, 200)}...`);


### PR DESCRIPTION
## Summary
The codebase had **~109 `console.log/info/debug` calls** scattered through `src/`, mostly QRZ/LoTW sync debug scaffolding and ADIF import batch tracers. They were development breadcrumbs that never got cleaned up — none shipped useful runtime info. This PR strips them and adds an ESLint rule so they can't quietly come back.

**Heavy hitters cleaned:**
- `src/app/api/contacts/qrz-sync/route.ts` — 28 per-contact debug traces
- `src/lib/qrz.ts` — 20 HTTP request/response traces
- `src/app/api/contacts/qrz-download/route.ts` — 8
- `src/app/api/install/finalize/route.ts` — 7 (one converted to `console.warn` for real)
- `src/app/api/cron/lotw-{download,upload}/route.ts` — 12 combined (auth/header debug + per-station progress)
- `src/app/api/adif/import/route.ts` + `src/components/AutoImportADIF.tsx` — 13 batch-progress traces
- `src/app/api/lotw/download{,-contact}/route.ts` — 12 credential-path traces
- `src/app/api/install/migrate-schema/route.ts` — 4
- Smaller cleanups in `UserContext`, `search/page`, `dxpeditions`

**Kept:**
- `console.error` in genuine error paths (unchanged policy)
- `console.warn` for real warnings (e.g. fallback paths in `Propagation`, install routes)
- The two intentional `console.log` calls in `src/lib/logger.ts` (with `eslint-disable-next-line` — the logger module is precisely what the rest of the codebase should use going forward)

**ESLint:**
- Added `no-console` rule with `allow: ['warn', 'error']` at **error** level
- Exempted `scripts/**/*.{js,mjs}` (CLI utilities legitimately use console)
- Exempted `tests/**/*.{ts,js}` (diagnostic output in test failures)

## Notes for review
- Also picks up the same one-line null-guard fix from #188 in `tests/database-integration.spec.ts` so this branch's `tsc --noEmit` runs clean independently of merge order. When #188 merges first, this will resolve as the same line.
- This builds on the policy laid out in CLAUDE.md (#188): \"no `console.log` in `src/` — phasing out, lint rule coming.\" This is that follow-up.

## Test plan
- [x] `npm run lint` — 0 errors, 52 warnings (unchanged baseline)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds
- [ ] Manual: trigger a QRZ sync, watch server logs — should be quiet except on errors
- [ ] Manual: run the install wizard end-to-end — should still succeed; warnings only on missing optional tables
- [ ] Cron: next scheduled LoTW upload/download — successful runs are silent; errors still log

🤖 Generated with [Claude Code](https://claude.com/claude-code)