### PR TITLE
chore(api): tighten error responses + document response patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,18 +28,39 @@ The database is `snake_case`. To eliminate boundary-translation bugs (the kind w
 
 ## Error response shape
 
-API routes return:
+Two acceptable patterns. Pick based on what consumers already expect.
+
+**Default — `{ error: string }` with HTTP status:**
 
 ```ts
-{ error: string }
+return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 });
 ```
 
-with an appropriate HTTP status (400 client error, 401 unauthorized, 403 forbidden, 404 not found, 500 server error). Some routes return richer shapes (`{ success: boolean, error?: string, ... }`) — that's fine where it's already established, but new routes should default to the simple shape.
+HTTP status carries the error category (400 client error, 401 unauthorized, 403 forbidden, 404 not found, 500 server error). New internal routes should default to this shape.
+
+**Discriminated union — `{ success, data, error }`:** used by `/api/awards/*` and the public-facing `/api/cloudlog/*`. Consumers check `data.success` to branch. The shape is part of the contract; don't change it without updating every consumer.
+
+```ts
+type AwardResponse<T> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+```
+
+**Don't leak raw error messages.** A `catch` block that returns `error.message` to the client can expose DB constraint names, stack frames, and other internals. Log the real message with `console.error` and return a generic string:
+
+```ts
+catch (error) {
+  console.error('DXCC summary error:', error);
+  return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+}
+```
+
+The `details:` field used by some install/cron routes (`{ error, details }`) is admin/diagnostic only and not consumed by the frontend — keep it scoped to flows where untrusted callers can't reach.
 
 ## Logging
 
-- `console.log` in `src/` is being phased out — don't add new ones. (Lint rule coming in a follow-up PR.)
-- `console.error` is acceptable in genuine error paths until a real logger is introduced.
+- `no-console` is lint-enforced in `src/` (allows `warn`, `error` only). Use `console.error` in genuine error paths; everything else should go through `src/lib/logger.ts` (`logger.debug` / `logger.info` / `logger.warn` / `logger.error`).
+- `scripts/` and `tests/` are exempt from the rule — CLI utilities and test diagnostics may use `console.log`.
 
 ## Type discipline
 

--- a/src/app/api/awards/dxcc/progress/route.ts
+++ b/src/app/api/awards/dxcc/progress/route.ts
@@ -39,7 +39,7 @@ export async function GET(request: NextRequest) {
     console.error('DXCC progress error:', error);
     const response: DXCCProgressResponse = {
       success: false,
-      error: error instanceof Error ? error.message : 'Internal server error'
+      error: 'Internal server error'
     };
     return NextResponse.json(response, { status: 500 });
   }
@@ -240,7 +240,7 @@ export async function POST(request: NextRequest) {
     console.error('DXCC progress POST error:', error);
     const response: DXCCProgressResponse = {
       success: false,
-      error: error instanceof Error ? error.message : 'Internal server error'
+      error: 'Internal server error'
     };
     return NextResponse.json(response, { status: 500 });
   }

--- a/src/app/api/awards/dxcc/summary/route.ts
+++ b/src/app/api/awards/dxcc/summary/route.ts
@@ -32,7 +32,7 @@ export async function GET(request: NextRequest) {
     console.error('DXCC summary error:', error);
     const response: DXCCSummaryResponse = {
       success: false,
-      error: error instanceof Error ? error.message : 'Internal server error'
+      error: 'Internal server error'
     };
     return NextResponse.json(response, { status: 500 });
   }

--- a/src/app/api/awards/was/progress/route.ts
+++ b/src/app/api/awards/was/progress/route.ts
@@ -39,7 +39,7 @@ export async function GET(request: NextRequest) {
     console.error('WAS progress error:', error);
     const response: WASProgressResponse = {
       success: false,
-      error: error instanceof Error ? error.message : 'Internal server error'
+      error: 'Internal server error'
     };
     return NextResponse.json(response, { status: 500 });
   }
@@ -213,7 +213,7 @@ export async function POST(request: NextRequest) {
     console.error('WAS progress POST error:', error);
     const response: WASProgressResponse = {
       success: false,
-      error: error instanceof Error ? error.message : 'Internal server error'
+      error: 'Internal server error'
     };
     return NextResponse.json(response, { status: 500 });
   }

--- a/src/app/api/awards/was/summary/route.ts
+++ b/src/app/api/awards/was/summary/route.ts
@@ -32,7 +32,7 @@ export async function GET(request: NextRequest) {
     console.error('WAS summary error:', error);
     const response: WASSummaryResponse = {
       success: false,
-      error: error instanceof Error ? error.message : 'Internal server error'
+      error: 'Internal server error'
     };
     return NextResponse.json(response, { status: 500 });
   }

--- a/src/app/api/lotw/download-contact/route.ts
+++ b/src/app/api/lotw/download-contact/route.ts
@@ -92,16 +92,7 @@ export async function POST(request: NextRequest) {
         ? 'LoTW credentials not configured. Please configure LoTW credentials in Settings > LoTW Integration (either at User level for all stations, or Station level for this specific station).'
         : 'LoTW credentials are incomplete or invalid. Please reconfigure them in Settings > LoTW Integration.';
 
-      return NextResponse.json({
-        error: errorMessage,
-        debug: {
-          station_id: contact.station_id,
-          station_callsign: contact.station_callsign,
-          credential_source: credentialSource,
-          has_username: !!lotwUsername,
-          has_password: !!lotwPassword
-        }
-      }, { status: 400 });
+      return NextResponse.json({ error: errorMessage }, { status: 400 });
     }
 
     // Create a date range around the contact (±1 day to be safe)

--- a/src/app/api/lotw/download/route.ts
+++ b/src/app/api/lotw/download/route.ts
@@ -104,16 +104,7 @@ export async function POST(request: NextRequest) {
         ? 'LoTW credentials not configured. Please configure LoTW credentials in Settings > LoTW Integration (either at User level for all stations, or Station level for this specific station).'
         : 'LoTW credentials are incomplete or invalid. Please reconfigure them in Settings > LoTW Integration.';
 
-      return NextResponse.json({
-        error: errorMessage,
-        debug: {
-          station_id: station_id,
-          station_callsign: station.callsign,
-          credential_source: credentialSource,
-          has_username: !!lotwUsername,
-          has_password: !!lotwPassword
-        }
-      }, { status: 400 });
+      return NextResponse.json({ error: errorMessage }, { status: 400 });
     }
 
     // Create download log entry


### PR DESCRIPTION
## Summary
Two concrete issues with error response bodies; both touched lightly so the PR stays small.

### 1. Awards routes stop leaking raw `error.message` (4 files)
`src/app/api/awards/{dxcc,was}/{progress,summary}/route.ts` had `catch` blocks returning `error: error instanceof Error ? error.message : 'Internal server error'` inside their typed responses. A failure on a DB query can surface column names, constraint names, or stack frames in the response body — useful in dev, a soft information-disclosure in prod. Fixed: the real error stays in `console.error` for server-side observability; the client gets `'Internal server error'`.

### 2. LoTW download routes drop `debug: {...}` blocks (2 files)
`src/app/api/lotw/download{,-contact}/route.ts` returned a `debug:` object alongside credential-error responses, exposing `has_username`/`has_password`/`credential_source`/station identifiers. Leftover from the QRZ debug-strip pass (#189) — the frontend never consumed these fields.

### What I deliberately did **not** change
- **`{ success, data, error }` discriminated union** in `/api/awards/*` stays. Four frontend components branch on `data.success`; it's an established contract.
- **`/api/cloudlog/*` `{ success, ...}` responses** stay. It's a public Cloudlog-compatible API for 3rd-party logging software — changing the shape breaks integrations.
- **`details:` field** on install/cron error responses stays. Admin/diagnostic flow only, not reachable by untrusted callers.

### CLAUDE.md
Updated to document:
- The two acceptable response patterns and when each applies
- Explicit \"don't leak raw `error.message`\" rule with an example
- The cloudlog/* external API contract
- Refreshed Logging section now that the `no-console` rule (#189) has landed; points new code at `src/lib/logger.ts`

## Test plan
- [x] `npm run lint` → unchanged from baseline (#190 still pending merge)
- [x] `npm run typecheck` → clean
- [x] `npm run build` → succeeds
- [ ] Manual: hit a DXCC/WAS award summary, simulate failure (e.g. drop a DB connection) — confirm response shows generic error, server log shows actual
- [ ] Manual: try LoTW per-contact download with missing creds — confirm error message displays, no `debug:` block in DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)