### PR TITLE
chore(cleanup): triage TODOs (9 → 1)

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -129,7 +129,6 @@ export default function AdminDashboard() {
     setSyncMessage(null);
     
     try {
-      // TODO: Implement bulk LoTW upload
       setSyncMessage({ type: 'error', text: 'LoTW bulk upload functionality coming soon!' });
     } finally {
       setLotwUploading(false);
@@ -141,7 +140,6 @@ export default function AdminDashboard() {
     setSyncMessage(null);
     
     try {
-      // TODO: Implement bulk LoTW download
       setSyncMessage({ type: 'error', text: 'LoTW bulk download functionality coming soon!' });
     } finally {
       setLotwDownloading(false);

--- a/src/app/api/awards/dxcc/summary/route.ts
+++ b/src/app/api/awards/dxcc/summary/route.ts
@@ -533,9 +533,14 @@ async function getDXCCStatistics(userId: number, stationId?: number) {
   
   const rarest = rarestResult.rows[0] || { name: 'None', contact_count: 0 };
 
+  // Minimal award tracking: DXCC Basic requires 100+ confirmed entities.
+  // total_dxcc_awards is the count of DXCC award tiers we currently track
+  // (just Basic); expand when adding 150/200/.../350 tiers, by-band, by-mode.
+  const dxccBasicEarned = totalEntitiesConfirmed >= 100 ? 1 : 0;
+
   return {
-    total_dxcc_awards: 0, // TODO: Calculate completed awards
-    completed_awards: 0, // TODO: Calculate completed awards
+    total_dxcc_awards: 1,
+    completed_awards: dxccBasicEarned,
     entities_worked_total: totalEntitiesWorked,
     entities_confirmed_total: totalEntitiesConfirmed,
     most_worked_continent: {

--- a/src/app/api/awards/was/summary/route.ts
+++ b/src/app/api/awards/was/summary/route.ts
@@ -443,9 +443,14 @@ async function getWASStatistics(userId: number, stationId?: number) {
   const mostWorked = statsResult.rows[0] || { state: 'None', contact_count: 0 };
   const leastWorked = statsResult.rows[statsResult.rows.length - 1] || { state: 'None', contact_count: 0 };
 
+  // Minimal award tracking: WAS Basic requires all 50 US states confirmed.
+  // total_was_awards is the count of WAS award tiers we currently track (just
+  // Basic); expand when adding 5-Band/Triple Play/etc.
+  const wasBasicEarned = totalStatesConfirmed >= 50 ? 1 : 0;
+
   return {
-    total_was_awards: 0, // TODO: Calculate completed awards
-    completed_awards: 0, // TODO: Calculate completed awards
+    total_was_awards: 1,
+    completed_awards: wasBasicEarned,
     states_worked_total: totalStatesWorked,
     states_confirmed_total: totalStatesConfirmed,
     most_worked_state: {

--- a/src/app/api/cloudlog/modes/route.ts
+++ b/src/app/api/cloudlog/modes/route.ts
@@ -132,9 +132,10 @@ export async function GET(request: NextRequest) {
       categories: Object.keys(AMATEUR_MODES)
     });
 
-    // Add rate limit headers
+    // Rate limit headers — enforcement isn't implemented yet, so Remaining == Limit
+    // until a real limiter lands (avoids the hardcoded "999" lie).
     response.headers.set('X-RateLimit-Limit', auth.rateLimitPerHour.toString());
-    response.headers.set('X-RateLimit-Remaining', '999'); // TODO: Get actual remaining
+    response.headers.set('X-RateLimit-Remaining', auth.rateLimitPerHour.toString());
     
     return addCorsHeaders(response);
 

--- a/src/app/api/cloudlog/qso/route.ts
+++ b/src/app/api/cloudlog/qso/route.ts
@@ -184,7 +184,10 @@ export async function GET(request: NextRequest) {
       }
     });
 
-    addRateLimitHeaders(response, 999, auth.rateLimitPerHour); // TODO: Get actual remaining from rate limiter
+    // Rate limit enforcement isn't implemented yet, so report Remaining == Limit
+    // until a real limiter lands. This keeps the documented headers truthful
+    // (rather than a hardcoded "999") while we ship.
+    addRateLimitHeaders(response, auth.rateLimitPerHour, auth.rateLimitPerHour);
     return addCorsHeaders(response);
 
   } catch (error) {

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -610,18 +610,10 @@ export default function SearchPage() {
       const data = await response.json();
       
       if (response.ok) {
-        // Refresh the contacts to get updated sync status
+        // Refresh the contacts; the sync indicators on each row reflect the
+        // per-contact result. (No toast system yet; visual refresh is the feedback.)
         await performSearch(filters, pagination.page);
         setSelectedContacts(new Set());
-        
-        // Show success message
-        const { successful, failed, skipped } = data.summary;
-        const messages = [];
-        if (successful > 0) messages.push(`${successful} contact(s) synced successfully`);
-        if (skipped > 0) messages.push(`${skipped} contact(s) skipped (already synced)`);
-        if (failed > 0) messages.push(`${failed} contact(s) failed to sync`);
-        
-        // TODO: surface QRZ sync results via toast notification
       } else {
         setError(data.error || 'Failed to sync contacts to QRZ');
       }


### PR DESCRIPTION
## Summary
Worked through every `TODO` in `src/`, sorted by what was actually actionable.

### Implemented (4 → 0)
**Awards completed-count calculation.** The `/awards` page displays "Awards Earned" prominently, and it was always showing 0 because the API hardcoded the field. Now reflects reality:
- `src/app/api/awards/was/summary/route.ts` — WAS Basic award = 1 if all 50 US states confirmed else 0. `total_was_awards = 1` (we track the Basic tier only — extensible when 5-Band / Triple Play / etc. are added).
- `src/app/api/awards/dxcc/summary/route.ts` — DXCC Basic = 1 if 100+ confirmed entities else 0. `total_dxcc_awards = 1` (extensible to 150/200/.../350, by-band, by-mode).

### Fixed an honest-output issue (2 → 0)
- `src/app/api/cloudlog/qso/route.ts:187` and `modes/route.ts:137` hardcoded `X-RateLimit-Remaining: 999`. The cloudlog index docs advertise rate-limit headers as part of the public API contract, but enforcement isn't implemented. Sending `999` to consumers is a lie. Now reports `Remaining == Limit` (effectively \"no enforcement, unlimited within the documented limit\") with a comment pointing at the path forward.

### Deleted as redundant (2 → 0)
- `src/app/admin/page.tsx:132,144` — `// TODO: Implement bulk LoTW {upload,download}` sat one line above `setSyncMessage('coming soon!')`. The UI message already documents the state; the TODO was clutter.

### Deleted as dead code (1 → 0)
- `src/app/search/page.tsx:624` — TODO marked a `messages` array that got built up but never displayed. Leftover from a `console.log` removed in #189. The actual user feedback (table refresh with new sync status indicators) still works.

### Kept (1 → 1)
- `src/lib/storage.ts:318` — `// TODO: Implement AWS S3 deletion`. The AWS S3 storage backend isn't implemented at all (`uploadToS3` also fails gracefully); this TODO accurately documents the unimplemented branch. Removing it doesn't help; implementing AWS S3 is its own future PR.

## Test plan
- [x] `npm run lint` — unchanged baseline
- [x] `npm run typecheck` — clean
- [x] `npm run build` — succeeds
- [ ] Manual: view `/awards` after confirming 50 states / 100 entities — confirm \"Awards Earned\" reflects the correct count (1 or 0)
- [ ] Manual: hit `/api/cloudlog/qso` with a valid API key — confirm `X-RateLimit-Remaining` header reads the same as `X-RateLimit-Limit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)