### PR TITLE
feat(install): swap UI to drizzle migrator (replaces 3 legacy endpoints)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,10 +94,10 @@ The canonical schema lives in TypeScript at `drizzle/schema.ts`. To evolve it:
 - For fresh DBs, applies the baseline normally to create all 18 tables.
 - Returns `{ backfilled, migrationsAppliedCount, baselineTag }`.
 
+**Install flow:** `/install` POSTs `/api/install/{validate,migrate,create-admin,finalize}` in order. The `migrate` step calls the runtime migrator (gated on "no users yet exist" instead of admin auth), which creates schema + loads reference data in one shot — same code path as `/api/admin/migrate`.
+
 **Current state (still deliberate limitations):**
-- The install UI still calls `/api/install/database` and `/api/install/migrate-schema` (the legacy SQL paths). Switching the UI over to `/api/admin/migrate` is a follow-up PR.
-- Legacy SQL files (`install-database.sql`, `propagation-schema.sql`, `postgres-lotw-migration.sql`, `migrations/*.sql`) still exist. Safe to delete only after the install UI uses `drizzle-kit migrate` exclusively and the runtime path is proven on at least one production install.
-- The baseline doesn't include the reference data INSERTs (DXCC entities, states/provinces) that `install-database.sql` ships. Fresh installs that *only* run the migrator will have empty `dxcc_entities` and `states_provinces` tables. A future migration should seed these.
+- Legacy SQL files (`install-database.sql`, `propagation-schema.sql`, `postgres-lotw-migration.sql`, `migrations/*.sql`) and the legacy install endpoints (`/api/install/{database,migrate-schema,reference-data}`) still exist on disk but are no longer called by the install UI. Safe to delete once the new install path is proven on at least one production install.
 - Local dev DBs bootstrapped via the old `postgres-init.sql` (deleted in #195) need to be wiped and re-installed via the in-app installer for parity. The dev-only `api_key_usage_logs` table is intentionally not canonical.
 
 ## Scripts (run from repo root)

--- a/src/app/api/install/migrate/route.ts
+++ b/src/app/api/install/migrate/route.ts
@@ -1,0 +1,73 @@
+// Install-time migration endpoint. Calls the same runner as
+// `/api/admin/migrate` but is gated on "no users yet exist" instead of
+// admin auth — during a fresh install there's no admin to authenticate as.
+//
+// Once an admin has been created (via /api/install/create-admin or the normal
+// signup flow), this endpoint refuses further runs and the admin endpoint
+// becomes the only way to apply pending migrations.
+
+import { NextResponse } from 'next/server';
+import { Pool } from 'pg';
+
+import { query } from '@/lib/db';
+import { runMigrations } from '@/lib/migrator';
+
+export async function POST() {
+  // Pre-flight: refuse if any user already exists. The long-lived shared pool
+  // is fine for this short read.
+  try {
+    const usersExists = await query(`
+      SELECT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'users'
+      ) AS exists
+    `);
+
+    if (usersExists.rows[0]?.exists) {
+      const userCount = await query('SELECT COUNT(*)::text AS count FROM users');
+      if (parseInt(userCount.rows[0]?.count ?? '0', 10) > 0) {
+        return NextResponse.json(
+          {
+            error:
+              'Installation already complete. Use /api/admin/migrate as an authenticated admin to run further migrations.',
+          },
+          { status: 400 }
+        );
+      }
+    }
+  } catch (error) {
+    console.error('Install migrate pre-flight error:', error);
+    return NextResponse.json(
+      {
+        error: 'Failed to verify installation state',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+
+  // Dedicated short-lived pool for the migration run — the migrator needs to
+  // close its connections when it finishes, and we don't want to disturb the
+  // shared long-lived pool that other endpoints rely on.
+  const migrationPool = new Pool({
+    connectionString: process.env.DATABASE_URL,
+    ssl: process.env.DATABASE_SSL === 'true' ? { rejectUnauthorized: false } : false,
+    max: 1,
+  });
+
+  try {
+    const result = await runMigrations(migrationPool);
+    return NextResponse.json({ success: true, ...result });
+  } catch (error) {
+    console.error('Install migrate run error:', error);
+    return NextResponse.json(
+      {
+        error: 'Failed to apply migrations',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  } finally {
+    await migrationPool.end();
+  }
+}

--- a/src/app/install/page.tsx
+++ b/src/app/install/page.tsx
@@ -32,9 +32,7 @@ export default function InstallPage() {
   const [installComplete, setInstallComplete] = useState(false);
   const [installSteps, setInstallSteps] = useState<InstallStep[]>([
     { id: 'validate', title: 'Validating installation requirements', status: 'pending' },
-    { id: 'database', title: 'Setting up database schema', status: 'pending' },
-    { id: 'migrate', title: 'Running database migrations', status: 'pending' },
-    { id: 'reference', title: 'Loading DXCC entities and reference data', status: 'pending' },
+    { id: 'migrate', title: 'Creating schema and loading reference data', status: 'pending' },
     { id: 'user', title: 'Creating administrator account', status: 'pending' },
     { id: 'finalize', title: 'Finalizing installation', status: 'pending' }
   ]);
@@ -101,56 +99,26 @@ export default function InstallPage() {
       
       updateStepStatus('validate', 'completed', 'System requirements validated');
 
-      // Step 2: Setup database
-      updateStepStatus('database', 'running');
-      await sleep(1500);
-      
-      const dbResponse = await fetch('/api/install/database', {
-        method: 'POST'
-      });
-      
-      if (!dbResponse.ok) {
-        const errorData = await dbResponse.json().catch(() => ({}));
-        throw new Error(errorData.error || 'Failed to create database schema. Please ensure PostgreSQL is running and accessible.');
-      }
-      
-      updateStepStatus('database', 'completed', 'Database schema created successfully');
-
-      // Step 3: Run schema migrations
+      // Step 2: Apply Drizzle migrations (creates schema + loads reference data)
       updateStepStatus('migrate', 'running');
-      await sleep(1000);
-      
-      const migrateResponse = await fetch('/api/install/migrate-schema', {
+
+      const migrateResponse = await fetch('/api/install/migrate', {
         method: 'POST'
       });
-      
+
       if (!migrateResponse.ok) {
         const errorData = await migrateResponse.json().catch(() => ({}));
-        throw new Error(errorData.error || 'Failed to run database migrations. Some features may not work properly.');
+        throw new Error(errorData.error || 'Failed to apply database migrations. Please ensure PostgreSQL is running and accessible.');
       }
-      
+
       const migrateResult = await migrateResponse.json();
-      updateStepStatus('migrate', 'completed', 
-        `Applied ${migrateResult.migrationsExecuted} database migrations`);
+      const appliedCount = migrateResult.migrationsAppliedCount ?? 0;
+      const detail = migrateResult.backfilled
+        ? `Backfilled existing schema and applied ${appliedCount} new migration${appliedCount === 1 ? '' : 's'}`
+        : `Applied ${appliedCount} migration${appliedCount === 1 ? '' : 's'} (schema + reference data)`;
+      updateStepStatus('migrate', 'completed', detail);
 
-      // Step 4: Load reference data
-      updateStepStatus('reference', 'running');
-      await sleep(3000); // This step takes longer
-      
-      const refDataResponse = await fetch('/api/install/reference-data', {
-        method: 'POST'
-      });
-      
-      if (!refDataResponse.ok) {
-        const errorData = await refDataResponse.json().catch(() => ({}));
-        throw new Error(errorData.error || 'Failed to load DXCC entities and reference data. This may be due to missing data files.');
-      }
-      
-      const refDataResult = await refDataResponse.json();
-      updateStepStatus('reference', 'completed', 
-        `Loaded ${refDataResult.dxccCount} DXCC entities and ${refDataResult.statesCount} states/provinces`);
-
-      // Step 5: Create admin user
+      // Step 3: Create admin user
       updateStepStatus('user', 'running');
       await sleep(1000);
       
@@ -175,7 +143,7 @@ export default function InstallPage() {
       
       updateStepStatus('user', 'completed', 'Administrator account created');
 
-      // Step 6: Finalize
+      // Step 4: Finalize
       updateStepStatus('finalize', 'running');
       await sleep(500);
       


### PR DESCRIPTION
## Summary

Closes the first of two deferred items from #196. Wires the install UI to the same migration runner as `/api/admin/migrate`, collapsing three install steps into one.

**Old flow (6 calls):** `validate` → `database` → `migrate-schema` → `reference-data` → `create-admin` → `finalize`
**New flow (4 calls):** `validate` → **`migrate`** → `create-admin` → `finalize`

## What's new

- **`POST /api/install/migrate`** — install-time wrapper around `runMigrations()`. Same code path as `/api/admin/migrate`, but gated on "no users yet exist" instead of admin auth (since during a fresh install there's no admin to authenticate as). Once an admin is created, the endpoint refuses further calls with a 400 directing the caller to the admin endpoint.
- **`src/app/install/page.tsx`** — drops the `database`, old `migrate`, and `reference-data` steps. The new `migrate` step does all three of their jobs via the migrator. Step counter goes from 6 to 4. Reports `backfilled` vs fresh in the step message so it's clear which scenario ran.
- **`CLAUDE.md`** — describes the new flow and notes that the legacy install endpoints + SQL files are now unreferenced (deletion gated on prod proof).

## Why this is better than the endpoints it replaces

| Replaced | Problem | How the migrator fixes it |
|---|---|---|
| `/api/install/database` | `docker cp` + `docker exec psql` against a hard-coded container name; fell back to inline DDL on failure | Pure Node — no docker dependency, runs on Vercel/serverless |
| `/api/install/migrate-schema` | Column-by-column ALTER TABLE patching for legacy schemas | Unnecessary — the baseline IS the canonical schema |
| `/api/install/reference-data` | Apostrophe bug (#198), brittle DROP/re-ADD CONSTRAINT dance for duplicates | Migration 0001 uses `''` escapes and `ON CONFLICT DO NOTHING` |

## What's NOT in this PR (deferred)

The legacy endpoints (`/api/install/{database,migrate-schema,reference-data}`) and SQL files (`install-database.sql`, `propagation-schema.sql`, `postgres-lotw-migration.sql`, `migrations/*.sql`) stay on disk. Deletion is the second deferred item from #196 — safe only after the new install path is proven on at least one production install.

## Verification

End-to-end against `postgres:15` in docker, fresh DB:

```
POST /api/install/validate
  → { success: true, message: "Fresh installation detected - ready to proceed" }

POST /api/install/migrate
  → { success: true, backfilled: false, migrationsAppliedCount: 2,
      baselineTag: "0000_baseline_canonical_schema" }
  Result in DB:
    tables: 18
    dxcc_entities: 402
    states_provinces: 1849
    drizzle migrations: 2
    unique constraints: dxcc_entities_adif_key, states_provinces_dxcc_entity_code_key

POST /api/install/create-admin { ... } → admin user id=1

POST /api/install/migrate (after admin exists)
  → 400 { error: "Installation already complete. Use /api/admin/migrate as
    an authenticated admin to run further migrations." }

POST /api/install/finalize
  → { success: true, stats: { tables: 18, adminUsers: 1, dxccEntities: 402,
      statesProvinces: 1849 } }
```

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build` — succeeds
- [ ] Reviewer can repro by spinning up a fresh DB and walking the `/install` flow in the browser

## Manual prod plan (when ready to ship)

1. Deploy this PR. Existing prod installs are unaffected — they already have users, so no one ever hits `/install` against them.
2. Spin up a fresh prod test instance (new DB, no admin). Walk through `/install` in the browser. Expect 4 steps to complete, ending on the login page.
3. After login, sanity-check `SELECT COUNT(*)` on `dxcc_entities` (402) and `states_provinces` (1849).
4. If anything's off, revert this PR — the legacy endpoints are still on disk and unreferenced; flipping `page.tsx` back to the old API calls would restore the prior flow.
5. Once proven, follow-up PR #2 deletes the legacy endpoints and SQL files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)