### PR TITLE
feat(api): add wavelog /api/statistics and /api/version stubs

### DIFF
--- a/src/app/api/statistics/route.ts
+++ b/src/app/api/statistics/route.ts
@@ -1,0 +1,65 @@
+// POST /api/statistics — wavelog wire-compatible QSO statistics.
+// Body: { "key": "nextlog_..." }
+// Returns 200 with { Today, total_qsos, month_qsos, year_qsos } counts for
+// the API key's owner. Some third-party clients (GridTracker, dashboards)
+// pre-flight this endpoint when validating an API key.
+
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyApiKeyValue } from '@/lib/api-auth';
+import { addCorsHeaders, createCorsPreflightResponse } from '@/lib/cors';
+import { query } from '@/lib/db';
+
+export async function OPTIONS() {
+  return createCorsPreflightResponse();
+}
+
+export async function POST(request: NextRequest) {
+  let key = '';
+  try {
+    const body = await request.json();
+    if (typeof body?.key === 'string') key = body.key;
+  } catch {
+    // fall through to auth failure
+  }
+
+  const authResult = await verifyApiKeyValue(key);
+  if (!authResult.success || !authResult.auth) {
+    return addCorsHeaders(
+      NextResponse.json(
+        { status: 'failed', reason: 'missing or invalid api key' },
+        { status: 401 },
+      ),
+    );
+  }
+  const auth = authResult.auth;
+
+  // Station scoping: if the key targets a single station, restrict counts to
+  // that station's QSOs; otherwise count across all of the user's stations.
+  const stationClause = auth.stationId !== null ? ' AND station_id = $2' : '';
+  const baseParams: (number | null)[] = auth.stationId !== null ? [auth.userId, auth.stationId] : [auth.userId];
+
+  const sql = `
+    SELECT
+      COUNT(*) FILTER (WHERE datetime >= date_trunc('day', CURRENT_TIMESTAMP AT TIME ZONE 'UTC')) AS today,
+      COUNT(*) FILTER (WHERE datetime >= date_trunc('month', CURRENT_TIMESTAMP AT TIME ZONE 'UTC')) AS month_qsos,
+      COUNT(*) FILTER (WHERE datetime >= date_trunc('year', CURRENT_TIMESTAMP AT TIME ZONE 'UTC')) AS year_qsos,
+      COUNT(*) AS total_qsos
+    FROM contacts
+    WHERE user_id = $1${stationClause}
+  `;
+
+  const result = await query(sql, baseParams);
+  const row = result.rows[0];
+
+  return addCorsHeaders(
+    NextResponse.json(
+      {
+        Today: Number(row.today),
+        total_qsos: Number(row.total_qsos),
+        month_qsos: Number(row.month_qsos),
+        year_qsos: Number(row.year_qsos),
+      },
+      { status: 200 },
+    ),
+  );
+}

--- a/src/app/api/version/route.ts
+++ b/src/app/api/version/route.ts
@@ -1,0 +1,42 @@
+// POST /api/version — wavelog wire-compatible version probe.
+// Body: { "key": "nextlog_..." }
+// Returns 200 { status: "ok", version: "<wavelog-compat-version>" } or 401 on bad key.
+//
+// The version string is what GridTracker / Log4OM-style clients compare
+// against to decide which features are available. We report a recent
+// wavelog version so clients enable the full feature set they'd use with
+// real wavelog.
+
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyApiKeyValue } from '@/lib/api-auth';
+import { addCorsHeaders, createCorsPreflightResponse } from '@/lib/cors';
+
+const WAVELOG_COMPAT_VERSION = '2.7.0';
+
+export async function OPTIONS() {
+  return createCorsPreflightResponse();
+}
+
+export async function POST(request: NextRequest) {
+  let key = '';
+  try {
+    const body = await request.json();
+    if (typeof body?.key === 'string') key = body.key;
+  } catch {
+    // fall through to auth failure
+  }
+
+  const authResult = await verifyApiKeyValue(key);
+  if (!authResult.success || !authResult.auth) {
+    return addCorsHeaders(
+      NextResponse.json(
+        { status: 'failed', reason: 'missing or invalid api key' },
+        { status: 401 },
+      ),
+    );
+  }
+
+  return addCorsHeaders(
+    NextResponse.json({ status: 'ok', version: WAVELOG_COMPAT_VERSION }, { status: 200 }),
+  );
+}


### PR DESCRIPTION
## Summary

Unblocks GridTracker (and similar Cloudlog-flavored clients) that pre-flight an API key by hitting `/api/statistics` before sending any QSOs. Without this endpoint, GT hangs at "Testing API Key" because it never gets a parseable response. Also adds `/api/version` since some GT builds probe it instead/additionally.

| Endpoint | Body | Success | Failure |
|---|---|---|---|
| `POST /api/statistics` | `{ key }` | 200 `{ Today, total_qsos, month_qsos, year_qsos }` | 401 `{ status, reason }` |
| `POST /api/version` | `{ key }` | 200 `{ status: 'ok', version: '2.7.0' }` | 401 `{ status, reason }` |

Counts in `/api/statistics` are computed in a single Postgres `FILTER` aggregate over `contacts` — one round-trip, no N+1. Day/month/year boundaries are anchored to UTC via `date_trunc('day'/'month'/'year', CURRENT_TIMESTAMP AT TIME ZONE 'UTC')` so the values match what UTC-displaying clients expect.

Both endpoints respect the per-key station scoping the rest of the wavelog endpoints honor — if `api_keys.station_id` is set, the counts and version are scoped to that station's data (no cross-station leakage from a single-station API key).

The version string reports `2.7.0` to match what `/api/cloudlog` already claims as the wavelog compatibility target. Clients use this to decide which features to enable; lying about it would degrade their behavior.

## Test plan

Tested locally against a postgres container loaded with a `pg_dump --schema-only` snapshot of the production schema, with two seed QSOs.

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `POST /api/statistics` with valid key → `{Today:2, total_qsos:2, month_qsos:2, year_qsos:2}` (matches DB row count)
- [x] `POST /api/statistics` with bad key → 401 `{status:"failed", reason:"missing or invalid api key"}`
- [x] `POST /api/version` with valid key → `{status:"ok", version:"2.7.0"}`
- [x] `POST /api/version` with bad key → 401 `{status:"failed", reason:"missing or invalid api key"}`
- [ ] After deploy: GridTracker no longer hangs at "Testing API Key" and successfully validates the connection

## Deploy

No migration needed — purely additive read-only endpoints. After merge + deploy, GT (and similar) should validate cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)