### PR TITLE
fix(api): accept GridTracker's auth POST and path-segment-key station_info

### DIFF
--- a/src/app/api/auth/[key]/route.ts
+++ b/src/app/api/auth/[key]/route.ts
@@ -1,7 +1,12 @@
-// GET /api/auth/<key> — wavelog wire-compatible API key validation.
+// /api/auth/<key> — wavelog wire-compatible API key validation.
 // Returns XML, matching wavelog's <auth>...</auth> shape. The HTTP status is
 // 200 regardless of whether the key is valid (matching wavelog's quirk —
 // clients distinguish via the body, not the status).
+//
+// Accepts both GET and POST: wavelog runs on CodeIgniter, whose controllers
+// answer any HTTP method by default, and several clients (GridTracker, in
+// particular) POST to this URL even though the key is in the path. Honor
+// both verbs so those clients work.
 
 import { NextRequest } from 'next/server';
 import { verifyApiKeyValue } from '@/lib/api-auth';
@@ -22,7 +27,7 @@ function invalidKeyResponse() {
   return xmlResponse('<auth>\n  <message>Key Invalid - either not found or disabled</message>\n</auth>');
 }
 
-export async function GET(
+async function handle(
   _request: NextRequest,
   { params }: { params: Promise<{ key: string }> },
 ) {
@@ -34,4 +39,19 @@ export async function GET(
 
   const rights = authResult.auth.isReadOnly ? 'r' : 'rw';
   return xmlResponse(`<auth>\n  <status>Valid</status>\n  <rights>${rights}</rights>\n</auth>`);
+}
+
+export const GET = handle;
+export const POST = handle;
+
+export function OPTIONS() {
+  return new Response(null, {
+    status: 200,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-API-Key',
+      'Access-Control-Max-Age': '86400',
+    },
+  });
 }

--- a/src/app/api/station_info/[key]/route.ts
+++ b/src/app/api/station_info/[key]/route.ts
@@ -1,0 +1,22 @@
+// POST /api/station_info/<key> — wavelog wire-compatible variant where the
+// API key is passed as a path segment. GridTracker uses this form when
+// fetching the station profile list after a successful auth.
+
+import { NextRequest } from 'next/server';
+import { stationInfoResponse } from '@/lib/station-info';
+import { createCorsPreflightResponse } from '@/lib/cors';
+
+export async function OPTIONS() {
+  return createCorsPreflightResponse();
+}
+
+async function handle(
+  _request: NextRequest,
+  { params }: { params: Promise<{ key: string }> },
+) {
+  const { key } = await params;
+  return stationInfoResponse(key);
+}
+
+export const GET = handle;
+export const POST = handle;

--- a/src/app/api/station_info/route.ts
+++ b/src/app/api/station_info/route.ts
@@ -1,13 +1,10 @@
 // POST /api/station_info — wavelog wire-compatible station profile listing.
 // Body: { "key": "nextlog_..." }
-// Returns 200 with an array of station profiles in wavelog's shape. Respects
-// per-key station scoping (api_keys.station_id): a key scoped to a single
-// station only sees that station.
+// See /api/station_info/[key] for GridTracker's path-segment-auth variant.
 
-import { NextRequest, NextResponse } from 'next/server';
-import { verifyApiKeyValue } from '@/lib/api-auth';
-import { addCorsHeaders, createCorsPreflightResponse } from '@/lib/cors';
-import { query } from '@/lib/db';
+import { NextRequest } from 'next/server';
+import { stationInfoResponse } from '@/lib/station-info';
+import { createCorsPreflightResponse } from '@/lib/cors';
 
 export async function OPTIONS() {
   return createCorsPreflightResponse();
@@ -21,37 +18,5 @@ export async function POST(request: NextRequest) {
   } catch {
     // fall through to auth failure
   }
-
-  const authResult = await verifyApiKeyValue(key);
-  if (!authResult.success || !authResult.auth) {
-    return addCorsHeaders(
-      NextResponse.json(
-        { status: 'failed', reason: 'missing or invalid api key' },
-        { status: 401 },
-      ),
-    );
-  }
-  const auth = authResult.auth;
-
-  const sql = auth.stationId !== null
-    ? 'SELECT id, station_name, grid_locator, callsign, is_active FROM stations WHERE user_id = $1 AND id = $2 ORDER BY id'
-    : 'SELECT id, station_name, grid_locator, callsign, is_active FROM stations WHERE user_id = $1 ORDER BY id';
-  const params = auth.stationId !== null ? [auth.userId, auth.stationId] : [auth.userId];
-
-  const result = await query(sql, params);
-
-  // Wavelog returns a plain JSON array (not wrapped in {success,...}), with
-  // station_active as 1/0 (not boolean) and a station_uuid string. Nextlog
-  // doesn't have a uuid column — return the id as a string so clients that
-  // key off it still get a stable value.
-  const stations = result.rows.map((row: Record<string, unknown>) => ({
-    station_id: row.id,
-    station_profile_name: row.station_name,
-    station_gridsquare: row.grid_locator ?? '',
-    station_callsign: row.callsign,
-    station_active: row.is_active ? 1 : 0,
-    station_uuid: String(row.id),
-  }));
-
-  return addCorsHeaders(NextResponse.json(stations, { status: 200 }));
+  return stationInfoResponse(key);
 }

--- a/src/lib/station-info.ts
+++ b/src/lib/station-info.ts
@@ -1,0 +1,39 @@
+// Shared response builder for wavelog-compatible station_info lookups.
+// Used by both /api/station_info (key in JSON body) and
+// /api/station_info/[key] (key as path segment — GridTracker's form).
+
+import { NextResponse } from 'next/server';
+import { verifyApiKeyValue } from '@/lib/api-auth';
+import { addCorsHeaders } from '@/lib/cors';
+import { query } from '@/lib/db';
+
+export async function stationInfoResponse(key: string) {
+  const authResult = await verifyApiKeyValue(key);
+  if (!authResult.success || !authResult.auth) {
+    return addCorsHeaders(
+      NextResponse.json(
+        { status: 'failed', reason: 'missing or invalid api key' },
+        { status: 401 },
+      ),
+    );
+  }
+  const auth = authResult.auth;
+
+  const sql = auth.stationId !== null
+    ? 'SELECT id, station_name, grid_locator, callsign, is_active FROM stations WHERE user_id = $1 AND id = $2 ORDER BY id'
+    : 'SELECT id, station_name, grid_locator, callsign, is_active FROM stations WHERE user_id = $1 ORDER BY id';
+  const params = auth.stationId !== null ? [auth.userId, auth.stationId] : [auth.userId];
+
+  const result = await query(sql, params);
+
+  const stations = result.rows.map((row: Record<string, unknown>) => ({
+    station_id: row.id,
+    station_profile_name: row.station_name,
+    station_gridsquare: row.grid_locator ?? '',
+    station_callsign: row.callsign,
+    station_active: row.is_active ? 1 : 0,
+    station_uuid: String(row.id),
+  }));
+
+  return addCorsHeaders(NextResponse.json(stations, { status: 200 }));
+}


### PR DESCRIPTION
## Summary

Fixes two real-world mismatches between GridTracker's Cloudlog client and what nextlog implemented. Verified by inspecting GT's `app.asar` (`src/renderer/lib/adif.js`) — functions `CloudlogTest`, `CloudlogTestApiKey`, `CloudlogGetProfiles`, `CloudlogFillProfiles`.

### Problem 1: `/api/auth/[key]` rejected POST

GT POSTs to `{URL}/index.php/api/auth/{KEY}` despite the key being in the path. Our handler only exported `GET`, so Vercel returned `405 Method Not Allowed` with `Content-Length: 0`. GT's response parser saw an empty buffer and rendered "Invalid Response" — the user's stall at "Testing API Key" followed by "Invalid Response".

**Fix:** alias `GET` and `POST` to a single handler. Also added an `OPTIONS` handler for CORS preflight. This matches wavelog/CodeIgniter behavior, where the same controller function answers any HTTP method.

### Problem 2: `/api/station_info/[key]` didn't exist

After auth succeeds, GT immediately fetches the station profile list at `{URL}/index.php/api/station_info/{KEY}` (key in path, empty body). Our existing `/api/station_info` only read the key from the JSON body, so the dynamic path 404'd → empty buffer → GT overwrote "OK" with "Invalid Response".

**Fix:** new `/api/station_info/[key]/route.ts` dynamic route that handles both GET and POST. Existing `/api/station_info` (body form) is preserved unchanged — both call into a shared `stationInfoResponse(key)` helper in `src/lib/station-info.ts` so they return byte-identical JSON.

## What's the same as before

- `/api/station_info` (body form, no path segment) — wire-compatible, no behavior change
- `/api/auth/[key]` for `GET` requests — same XML response as before
- All other endpoints

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `POST /api/auth/<key>` → 200 XML `<status>Valid</status><rights>rw</rights>` (was 405)
- [x] `POST /api/station_info/<key>` → 200 JSON station array
- [x] `POST /api/station_info` (body form) → 200 JSON station array (regression check, unchanged)
- [ ] After deploy: GridTracker's Test button shows "OK" and populates the station profile dropdown

## How the bug was found

User reported GT stuck at "Testing API Key" then flipping to "Invalid Response". GT's renderer log (`%APPDATA%\GridTracker2\logs\main.log`) showed `Unexpected token '<'` JSON parse errors — confirming GT was getting HTML/empty body instead of expected response. Extracted GT's `app.asar`, read the actual `CloudlogTest` / `CloudlogGetProfiles` functions, found the two URL forms GT uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)