### PR TITLE
fix(lotw): stop /lotw page from refetching in an infinite loop

### DIFF
--- a/src/app/lotw/page.tsx
+++ b/src/app/lotw/page.tsx
@@ -67,55 +67,60 @@ export default function LotwPage() {
   const [certPassword, setCertPassword] = useState('');
   const [showCertPassword, setShowCertPassword] = useState(false);
 
-  const { user } = useUser();
+  const { user, loading: userLoading } = useUser();
   const router = useRouter();
 
+  // loadData is intentionally dep-free. setSelectedStation uses a functional
+  // updater so we don't need selectedStation in deps, and setLoading flips
+  // are internal — including them in useEffect's deps would create an
+  // infinite refetch loop (page used to hammer /api/stations + /api/lotw/*).
   const loadData = useCallback(async () => {
     try {
       setLoading(true);
-      
-      // Load stations
+
       const stationsResponse = await fetch('/api/stations');
       if (stationsResponse.ok) {
         const stationsData = await stationsResponse.json();
-        setStations(stationsData.stations || []);
-        
-        // Set default station if none selected
-        if (!selectedStation && stationsData.stations?.length > 0) {
-          const defaultStation = stationsData.stations.find((s: Station) => s.is_default) || stationsData.stations[0];
-          setSelectedStation(defaultStation.id.toString());
-        }
+        const fetchedStations: Station[] = stationsData.stations || [];
+        setStations(fetchedStations);
+
+        // Pick a default station only if one isn't already chosen.
+        setSelectedStation((prev) => {
+          if (prev) return prev;
+          const def = fetchedStations.find((s) => s.is_default) || fetchedStations[0];
+          return def ? def.id.toString() : '';
+        });
       }
 
-      // Load upload logs
       const uploadResponse = await fetch('/api/lotw/upload');
       if (uploadResponse.ok) {
         const uploadData = await uploadResponse.json();
         setUploadLogs(uploadData.upload_logs || []);
       }
 
-      // Load download logs
       const downloadResponse = await fetch('/api/lotw/download');
       if (downloadResponse.ok) {
         const downloadData = await downloadResponse.json();
         setDownloadLogs(downloadData.download_logs || []);
       }
-
     } catch (error) {
       console.error('Failed to load data:', error);
       setMessage({ type: 'error', text: 'Failed to load LoTW data' });
     } finally {
       setLoading(false);
     }
-  }, [selectedStation]);
+  }, []);
 
   useEffect(() => {
-    if (!user && !loading) {
+    // Wait for the auth context to finish its initial /api/user check before
+    // deciding anything — user is null both pre-resolve and when unauthed.
+    if (userLoading) return;
+    if (!user) {
       router.push('/login');
       return;
     }
     loadData();
-  }, [user, router, loading, loadData]);
+  }, [user, userLoading, router, loadData]);
 
   const handleUpload = async () => {
     if (!selectedStation) {


### PR DESCRIPTION
## Summary

The `/lotw` page hammered `/api/stations`, `/api/lotw/upload`, and `/api/lotw/download` continuously after mount. User reported it visually in Network tab; root cause is a triple-cycle React deps tangle:

1. `useEffect` deps included `loading` and `loadData`.
2. `loadData` calls `setLoading(true)` on entry and `setLoading(false)` on finish — every flip retriggers the effect.
3. `loadData`'s `useCallback` deps included `selectedStation`, and `loadData` itself called `setSelectedStation(...)` to pick a default — that state change reissues `loadData`'s identity, which is also a useEffect dep.

Each of #1 or #2/#3 alone produces an infinite loop. Combined: continuous refetches.

## Fix

- `loadData` `useCallback` deps now `[]`. The default-station selection uses `setSelectedStation((prev) => prev || derive(fetched))` so it doesn't depend on the current `selectedStation` value.
- `useEffect` no longer depends on this component's `loading` — only on `user`, `userLoading` from `UserContext`, `router`, and the now-stable `loadData`.
- Auth-gate honors `UserContext.loading` so it doesn't bounce to `/login` during the initial `/api/user` check (`user` is `null` both pre-resolve and when unauthenticated).

Net: page mounts → exactly one fetch round → idle. The manual Refresh button and post-action reloads still call `loadData` explicitly.

## Audit

Grepped the rest of `src/app/**/page.tsx` for the same pattern — `/lotw` was the only page with this exact tangle, so this is a one-file change.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [ ] After deploy: open `/lotw` with DevTools → Network filtered to `lotw|stations` and confirm only one round of requests fires on mount; further requests only happen when clicking Refresh or after Upload/Download actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)