### PR TITLE
feat(ui): make the app mobile-responsive

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, type ReactNode } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { Loader2, Plus, Search } from 'lucide-react';
@@ -127,6 +127,17 @@ function formatRelativeTime(date: string) {
 function formatUtc(date: string) {
   const d = new Date(date);
   return `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')} UTC`;
+}
+
+function MobileCardRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex justify-between items-center gap-3 py-1 text-[14px]">
+      <span className="text-[11px] uppercase tracking-[0.08em] font-semibold text-fg-2">
+        {label}
+      </span>
+      <span className="text-fg text-right">{children}</span>
+    </div>
+  );
 }
 
 export default function DashboardPage() {
@@ -290,7 +301,7 @@ export default function DashboardPage() {
     <div className="min-h-screen">
       <Navbar />
 
-      <main className="max-w-[1400px] mx-auto px-6 lg:px-8 py-8">
+      <main className="max-w-[1400px] mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
         <PageHeader
           title={
             <>
@@ -343,19 +354,16 @@ export default function DashboardPage() {
         </div>
 
         {/* Map + Quick Log */}
-        <div
-          className="grid gap-5 mb-6"
-          style={{ gridTemplateColumns: 'minmax(0, 1.55fr) minmax(0, 1fr)' }}
-        >
+        <div className="grid gap-5 mb-6 grid-cols-1 lg:[grid-template-columns:minmax(0,1.55fr)_minmax(0,1fr)]">
           <Card className="overflow-hidden p-0">
             {error && (
               <div className="bg-bad/10 border-b border-bad/20 text-bad px-4 py-3 text-sm">
                 {error}
               </div>
             )}
-            <div className="relative h-[460px]">
-              <DynamicContactMap contacts={contacts} user={user} height="460px" />
-              <div className="absolute top-4 left-4 flex gap-2 z-[400]">
+            <div className="relative h-[320px] sm:h-[460px]">
+              <DynamicContactMap contacts={contacts} user={user} height="100%" />
+              <div className="absolute top-4 left-4 flex flex-wrap gap-2 z-[400]">
                 <Chip>
                   <Dot tone="ok" live />
                   Worldmap
@@ -367,7 +375,7 @@ export default function DashboardPage() {
             </div>
           </Card>
 
-          <Card className="p-7 flex flex-col gap-5">
+          <Card className="p-4 sm:p-7 flex flex-col gap-5">
             <div className="flex items-center justify-between">
               <h2 className="text-[17px] font-semibold">Quick log</h2>
               <Chip variant="accent" size="sm">
@@ -428,7 +436,7 @@ export default function DashboardPage() {
               onChange={setBandRange}
             />
           </div>
-          <div className="flex gap-1.5 p-3 bg-bg-1 border border-line rounded-[12px]">
+          <div className="grid grid-cols-4 sm:grid-cols-6 md:flex gap-1.5 p-2.5 sm:p-3 bg-bg-1 border border-line rounded-[12px]">
             {BAND_ORDER.map((band) => {
               const count = bandActivity[band] ?? 0;
               const filled = activityBars(count);
@@ -437,7 +445,7 @@ export default function DashboardPage() {
                 <div
                   key={band}
                   className={[
-                    'flex-1 text-center px-2 py-3 rounded-[8px] border font-mono text-[13px] transition-colors cursor-default',
+                    'md:flex-1 text-center px-2 py-3 rounded-[8px] border font-mono text-[13px] transition-colors cursor-default',
                     isActive
                       ? 'border-accent bg-accent-soft text-accent-hi'
                       : 'border-transparent bg-white/[0.015] text-fg-2 hover:bg-white/[0.04] hover:text-fg',
@@ -463,19 +471,16 @@ export default function DashboardPage() {
         </Card>
 
         {/* Log + DXpeditions */}
-        <div
-          className="grid gap-5"
-          style={{ gridTemplateColumns: 'minmax(0, 1fr) 340px' }}
-        >
+        <div className="grid gap-5 grid-cols-1 lg:[grid-template-columns:minmax(0,1fr)_340px]">
           <Card className="overflow-hidden p-0">
-            <div className="flex items-center gap-3 px-5 py-4 border-b border-line">
-              <div className="flex-1 flex items-center gap-2.5 px-3.5 py-2 bg-bg-1 border border-line-hi rounded-[10px]">
-                <Search className="h-4 w-4 text-fg-2" />
+            <div className="flex flex-wrap items-center gap-2 sm:gap-3 px-3 sm:px-5 py-3 sm:py-4 border-b border-line">
+              <div className="flex-1 min-w-0 basis-full sm:basis-auto flex items-center gap-2.5 px-3.5 py-2 bg-bg-1 border border-line-hi rounded-[10px]">
+                <Search className="h-4 w-4 text-fg-2 shrink-0" />
                 <input
                   value={tableSearch}
                   onChange={(e) => setTableSearch(e.target.value)}
                   placeholder="Search callsign, name, grid, frequency…"
-                  className="flex-1 bg-transparent border-0 outline-none text-fg text-[15px] placeholder:text-fg-3"
+                  className="flex-1 min-w-0 bg-transparent border-0 outline-none text-fg text-[15px] placeholder:text-fg-3"
                 />
                 <Kbd>/</Kbd>
               </div>
@@ -496,105 +501,168 @@ export default function DashboardPage() {
                 </p>
               </div>
             ) : (
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Callsign</TableHead>
-                    <TableHead>When</TableHead>
-                    <TableHead>Band / Mode</TableHead>
-                    <TableHead>Freq</TableHead>
-                    <TableHead>RST</TableHead>
-                    <TableHead>Operator</TableHead>
-                    <TableHead>QSL</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
+              <>
+                {/* Desktop: classic table */}
+                <div className="hidden md:block">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Callsign</TableHead>
+                        <TableHead>When</TableHead>
+                        <TableHead>Band / Mode</TableHead>
+                        <TableHead>Freq</TableHead>
+                        <TableHead>RST</TableHead>
+                        <TableHead>Operator</TableHead>
+                        <TableHead>QSL</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {loading ? (
+                        <TableRow>
+                          <TableCell colSpan={7} className="text-center py-10">
+                            <div className="flex items-center justify-center gap-2 text-fg-2">
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                              Loading contacts…
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      ) : filteredContacts.length === 0 ? (
+                        <TableRow>
+                          <TableCell colSpan={7} className="text-center py-10 text-fg-2">
+                            No contacts match those filters.
+                          </TableCell>
+                        </TableRow>
+                      ) : (
+                        filteredContacts.map((contact) => (
+                          <TableRow
+                            key={contact.id}
+                            className="cursor-pointer"
+                            onClick={() => handleContactClick(contact)}
+                          >
+                            <TableCell>
+                              <span className="font-mono font-semibold text-fg text-[16px]">
+                                {contact.callsign}
+                              </span>
+                            </TableCell>
+                            <TableCell>
+                              {formatUtc(contact.datetime)}
+                              <br />
+                              <span className="text-[13px] text-fg-2">
+                                {formatRelativeTime(contact.datetime)}
+                              </span>
+                            </TableCell>
+                            <TableCell>
+                              <div className="flex gap-1.5 flex-wrap">
+                                <Chip size="sm">{contact.band}</Chip>
+                                <Chip size="sm">{contact.mode}</Chip>
+                              </div>
+                            </TableCell>
+                            <TableCell>
+                              <span className="font-mono text-fg-1">
+                                {contact.frequency}
+                              </span>
+                            </TableCell>
+                            <TableCell>
+                              <span className="font-mono text-fg-1">
+                                {contact.rst_sent ?? '-'} / {contact.rst_received ?? '-'}
+                              </span>
+                            </TableCell>
+                            <TableCell>
+                              {contact.name ?? '—'}
+                              {contact.qth ? (
+                                <span className="text-[13px] text-fg-2"> · {contact.qth}</span>
+                              ) : null}
+                            </TableCell>
+                            <TableCell>
+                              <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
+                                {qslChip(contact)}
+                                <span className="hidden xl:flex items-center gap-1.5">
+                                  <LotwSyncIndicator
+                                    lotwQslSent={contact.lotw_qsl_sent}
+                                    lotwQslRcvd={contact.lotw_qsl_rcvd}
+                                    qslLotw={contact.qsl_lotw}
+                                    qslLotwDate={contact.qsl_lotw_date}
+                                    lotwMatchStatus={contact.lotw_match_status}
+                                    contactId={contact.id}
+                                    stationId={contact.station_id}
+                                    onStatusChange={() => fetchContacts()}
+                                    size="sm"
+                                  />
+                                  <QRZSyncIndicator
+                                    qrzQslSent={contact.qrz_qsl_sent}
+                                    qrzQslSentDate={contact.qrz_qsl_sent_date}
+                                    qrzQslRcvd={contact.qrz_qsl_rcvd}
+                                    qrzQslRcvdDate={contact.qrz_qsl_rcvd_date}
+                                    size="sm"
+                                  />
+                                </span>
+                              </div>
+                            </TableCell>
+                          </TableRow>
+                        ))
+                      )}
+                    </TableBody>
+                  </Table>
+                </div>
+
+                {/* Mobile: stacked QSO cards */}
+                <div className="md:hidden flex flex-col gap-2.5 p-3">
                   {loading ? (
-                    <TableRow>
-                      <TableCell colSpan={7} className="text-center py-10">
-                        <div className="flex items-center justify-center gap-2 text-fg-2">
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                          Loading contacts…
-                        </div>
-                      </TableCell>
-                    </TableRow>
+                    <div className="flex items-center justify-center gap-2 py-10 text-fg-2">
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Loading contacts…
+                    </div>
                   ) : filteredContacts.length === 0 ? (
-                    <TableRow>
-                      <TableCell colSpan={7} className="text-center py-10 text-fg-2">
-                        No contacts match those filters.
-                      </TableCell>
-                    </TableRow>
+                    <div className="text-center py-10 text-fg-2">
+                      No contacts match those filters.
+                    </div>
                   ) : (
                     filteredContacts.map((contact) => (
-                      <TableRow
+                      <button
                         key={contact.id}
-                        className="cursor-pointer"
+                        type="button"
                         onClick={() => handleContactClick(contact)}
+                        className="rounded-xl border border-line bg-bg-1 p-3.5 text-left cursor-pointer hover:border-line-hi transition-colors"
                       >
-                        <TableCell>
-                          <span className="font-mono font-semibold text-fg text-[16px]">
+                        <div className="pb-2.5 mb-2 border-b border-line flex justify-between items-center gap-3">
+                          <span className="font-mono font-semibold text-fg text-lg">
                             {contact.callsign}
                           </span>
-                        </TableCell>
-                        <TableCell>
-                          {formatUtc(contact.datetime)}
-                          <br />
-                          <span className="text-[13px] text-fg-2">
-                            {formatRelativeTime(contact.datetime)}
+                          {qslChip(contact)}
+                        </div>
+                        <MobileCardRow label="When">
+                          <span>
+                            {formatUtc(contact.datetime)}{' '}
+                            <span className="text-fg-2">· {formatRelativeTime(contact.datetime)}</span>
                           </span>
-                        </TableCell>
-                        <TableCell>
-                          <div className="flex gap-1.5 flex-wrap">
+                        </MobileCardRow>
+                        <MobileCardRow label="Band / Mode">
+                          <span className="flex gap-1.5 flex-wrap justify-end">
                             <Chip size="sm">{contact.band}</Chip>
                             <Chip size="sm">{contact.mode}</Chip>
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          <span className="font-mono text-fg-1">
-                            {contact.frequency}
                           </span>
-                        </TableCell>
-                        <TableCell>
+                        </MobileCardRow>
+                        <MobileCardRow label="Freq">
+                          <span className="font-mono text-fg-1">{contact.frequency}</span>
+                        </MobileCardRow>
+                        <MobileCardRow label="RST">
                           <span className="font-mono text-fg-1">
                             {contact.rst_sent ?? '-'} / {contact.rst_received ?? '-'}
                           </span>
-                        </TableCell>
-                        <TableCell>
-                          {contact.name ?? '—'}
-                          {contact.qth ? (
-                            <span className="text-[13px] text-fg-2"> · {contact.qth}</span>
-                          ) : null}
-                        </TableCell>
-                        <TableCell>
-                          <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
-                            {qslChip(contact)}
-                            <span className="hidden xl:flex items-center gap-1.5">
-                              <LotwSyncIndicator
-                                lotwQslSent={contact.lotw_qsl_sent}
-                                lotwQslRcvd={contact.lotw_qsl_rcvd}
-                                qslLotw={contact.qsl_lotw}
-                                qslLotwDate={contact.qsl_lotw_date}
-                                lotwMatchStatus={contact.lotw_match_status}
-                                contactId={contact.id}
-                                stationId={contact.station_id}
-                                onStatusChange={() => fetchContacts()}
-                                size="sm"
-                              />
-                              <QRZSyncIndicator
-                                qrzQslSent={contact.qrz_qsl_sent}
-                                qrzQslSentDate={contact.qrz_qsl_sent_date}
-                                qrzQslRcvd={contact.qrz_qsl_rcvd}
-                                qrzQslRcvdDate={contact.qrz_qsl_rcvd_date}
-                                size="sm"
-                              />
-                            </span>
-                          </div>
-                        </TableCell>
-                      </TableRow>
+                        </MobileCardRow>
+                        <MobileCardRow label="Operator">
+                          <span className="text-right">
+                            {contact.name ?? '—'}
+                            {contact.qth ? (
+                              <span className="text-[13px] text-fg-2"> · {contact.qth}</span>
+                            ) : null}
+                          </span>
+                        </MobileCardRow>
+                      </button>
                     ))
                   )}
-                </TableBody>
-              </Table>
+                </div>
+              </>
             )}
 
             {pagination.pages > 1 && (

--- a/src/app/new-contact/page.tsx
+++ b/src/app/new-contact/page.tsx
@@ -424,7 +424,7 @@ export default function NewContactPage() {
     <div className="min-h-screen">
       <Navbar />
 
-      <main className="max-w-[1400px] mx-auto px-6 lg:px-8 py-8">
+      <main className="max-w-[1400px] mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
         <PageHeader
           title="Log a contact"
           sub={
@@ -449,15 +449,12 @@ export default function NewContactPage() {
         />
 
         <form onSubmit={handleSubmit}>
-          <div
-            className="grid gap-6"
-            style={{ gridTemplateColumns: 'minmax(0, 1.4fr) minmax(0, 1fr)' }}
-          >
+          <div className="grid gap-6 grid-cols-1 xl:[grid-template-columns:minmax(0,1.4fr)_minmax(0,1fr)]">
             {/* LEFT — form */}
             <div className="flex flex-col gap-5 min-w-0">
               {/* Callsign hero */}
               <Card
-                className="p-8 flex flex-col gap-5"
+                className="p-5 sm:p-8 flex flex-col gap-5"
                 style={{
                   background:
                     'linear-gradient(180deg, rgba(77,208,255,0.04), transparent 60%), var(--card)',
@@ -483,7 +480,7 @@ export default function NewContactPage() {
                     placeholder="W1AW"
                     autoComplete="off"
                     className={cn(
-                      'w-full bg-transparent border-0 border-b-2 border-line-hi text-fg font-mono text-[56px] font-semibold tracking-[0.04em] py-4 outline-none transition-colors uppercase placeholder:text-fg-3',
+                      'w-full bg-transparent border-0 border-b-2 border-line-hi text-fg font-mono text-[32px] sm:text-[56px] font-semibold tracking-[0.04em] py-3 sm:py-4 outline-none transition-colors uppercase placeholder:text-fg-3',
                       'focus:border-accent',
                       validationErrors.callsign ? 'border-bad' : ''
                     )}
@@ -501,16 +498,15 @@ export default function NewContactPage() {
                 {lookupResult ? (
                   lookupResult.found ? (
                     <div
-                      className="grid items-center gap-4 p-4 rounded-[14px] border border-accent-glow"
+                      className="grid items-center gap-4 p-4 rounded-[14px] border border-accent-glow [grid-template-columns:48px_1fr] sm:[grid-template-columns:56px_1fr_auto]"
                       style={{
-                        gridTemplateColumns: '56px 1fr auto',
                         background:
                           'linear-gradient(180deg, var(--accent-soft), transparent), var(--bg-1)',
                       }}
                     >
                       <div
                         aria-hidden="true"
-                        className="w-14 h-14 rounded-[12px] grid place-items-center text-[#051018] font-mono font-bold text-lg"
+                        className="w-12 h-12 sm:w-14 sm:h-14 rounded-[12px] grid place-items-center text-[#051018] font-mono font-bold text-lg"
                         style={{
                           background:
                             'linear-gradient(135deg, var(--accent), #7a9bff)',
@@ -535,7 +531,7 @@ export default function NewContactPage() {
                           </div>
                         ) : null}
                       </div>
-                      <Chip variant="ok">
+                      <Chip variant="ok" className="col-span-2 sm:col-span-1 justify-self-start sm:justify-self-auto">
                         <Check className="h-3.5 w-3.5" />
                         Verified
                       </Chip>
@@ -550,7 +546,7 @@ export default function NewContactPage() {
               </Card>
 
               {/* Band & Mode */}
-              <Card className="p-6">
+              <Card className="p-4 sm:p-6">
                 <div className="flex items-center justify-between mb-4">
                   <h3 className="text-[17px] font-semibold">Band &amp; Mode</h3>
                   {formData.frequency ? (
@@ -643,7 +639,7 @@ export default function NewContactPage() {
               </Card>
 
               {/* Signal report & details */}
-              <Card className="p-6">
+              <Card className="p-4 sm:p-6">
                 <h3 className="text-[17px] font-semibold mb-4">
                   Signal report &amp; details
                 </h3>
@@ -792,12 +788,12 @@ export default function NewContactPage() {
                 </div>
               ) : null}
 
-              <div className="flex items-center gap-3 pt-1">
-                <Button asChild variant="secondary">
+              <div className="flex flex-col-reverse sm:flex-row sm:items-center gap-3 pt-1">
+                <Button asChild variant="secondary" className="w-full sm:w-auto">
                   <Link href="/dashboard">Cancel</Link>
                 </Button>
-                <div className="flex-1" />
-                <Button type="submit" size="lg" disabled={isLoading}>
+                <div className="hidden sm:block sm:flex-1" />
+                <Button type="submit" size="lg" disabled={isLoading} className="w-full sm:w-auto">
                   {isLoading ? (
                     <>
                       <Loader2 className="animate-spin" />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -129,7 +129,7 @@ export default function Home() {
   return (
     <div className="flex-1">
       {/* Transparent landing topbar */}
-      <header className="flex items-center gap-7 px-10 py-6">
+      <header className="flex items-center gap-4 sm:gap-7 px-4 sm:px-6 lg:px-10 py-4 sm:py-6">
         <BrandLockup href="/" />
         <nav className="hidden md:flex items-center gap-1 ml-2">
           <a
@@ -145,8 +145,8 @@ export default function Home() {
             Dashboard
           </Link>
         </nav>
-        <div className="ml-auto flex items-center gap-3">
-          <Button asChild variant="ghost">
+        <div className="ml-auto flex items-center gap-2 sm:gap-3">
+          <Button asChild variant="ghost" className="hidden sm:inline-flex">
             <Link href="/login">Sign in</Link>
           </Button>
           <Button asChild>
@@ -156,7 +156,7 @@ export default function Home() {
       </header>
 
       {/* Hero */}
-      <section className="px-10 pt-20 pb-16 max-w-[1280px] mx-auto text-center">
+      <section className="px-4 sm:px-6 lg:px-10 pt-12 sm:pt-20 pb-12 sm:pb-16 max-w-[1280px] mx-auto text-center">
         <Chip variant="accent" className="mb-7">
           <Dot tone="ok" live />
           Open source · self-host or cloud
@@ -197,18 +197,18 @@ export default function Home() {
           Log a QSO in three keystrokes, sync to LoTW &amp; QRZ automatically,
           and watch your contacts light up the world.
         </p>
-        <div className="flex flex-col sm:flex-row gap-3 justify-center items-center">
-          <Button asChild size="lg">
+        <div className="flex flex-col sm:flex-row gap-3 justify-center sm:items-center">
+          <Button asChild size="lg" className="w-full sm:w-auto">
             <Link href="/register">Try it free</Link>
           </Button>
-          <Button asChild variant="secondary" size="lg">
+          <Button asChild variant="secondary" size="lg" className="w-full sm:w-auto">
             <Link href="/dashboard">See live logging</Link>
           </Button>
         </div>
       </section>
 
       {/* Preview mockup */}
-      <div className="relative max-w-[1280px] mx-auto px-10 pb-24">
+      <div className="relative max-w-[1280px] mx-auto px-4 sm:px-6 lg:px-10 pb-16 sm:pb-24">
         <div
           className="absolute pointer-events-none"
           style={{
@@ -241,11 +241,11 @@ export default function Home() {
               </Chip>
             </div>
           </div>
-          <div className="grid min-h-[460px]" style={{ gridTemplateColumns: '1.6fr 1fr' }}>
+          <div className="grid min-h-[460px] grid-cols-1 lg:[grid-template-columns:1.6fr_1fr]">
             <WorldBackdrop
               pins={PREVIEW_PINS}
               arcs={PREVIEW_ARCS}
-              className="border-r border-line"
+              className="border-b lg:border-b-0 lg:border-r border-line min-h-[260px]"
             >
               <div className="absolute top-4 left-4 z-10">
                 <Chip>
@@ -300,7 +300,7 @@ export default function Home() {
       {/* Features */}
       <section
         id="features"
-        className="max-w-[1280px] mx-auto px-10 py-20"
+        className="max-w-[1280px] mx-auto px-4 sm:px-6 lg:px-10 py-12 sm:py-20"
       >
         <div className="text-[13px] font-mono text-accent uppercase tracking-[0.12em] mb-3.5">
           Built for operators
@@ -340,9 +340,8 @@ export default function Home() {
 
       {/* CTA */}
       <section
-        className="relative mx-10 mb-20 rounded-[28px] overflow-hidden border border-line-hi text-center"
+        className="relative mx-4 sm:mx-6 lg:mx-10 mb-12 sm:mb-20 px-5 sm:px-10 py-12 sm:py-20 rounded-[28px] overflow-hidden border border-line-hi text-center"
         style={{
-          padding: '80px 40px',
           background:
             'radial-gradient(800px 400px at 50% 100%, rgba(77,208,255,0.18), transparent 60%), radial-gradient(600px 300px at 50% 0%, rgba(167,139,250,0.12), transparent 60%), linear-gradient(180deg, #131923, #0e131c)',
         }}
@@ -370,11 +369,11 @@ export default function Home() {
           <p className="text-lg text-fg-1 mb-8">
             Free to self-host. Open source. Ready when you are.
           </p>
-          <div className="flex flex-col sm:flex-row gap-3 justify-center items-center">
-            <Button asChild size="lg">
+          <div className="flex flex-col sm:flex-row gap-3 justify-center sm:items-center">
+            <Button asChild size="lg" className="w-full sm:w-auto">
               <Link href="/register">Start logging</Link>
             </Button>
-            <Button asChild variant="secondary" size="lg">
+            <Button asChild variant="secondary" size="lg" className="w-full sm:w-auto">
               <a
                 href="https://github.com/patrickrb/nextlog"
                 target="_blank"

--- a/src/components/EditContactDialog.tsx
+++ b/src/components/EditContactDialog.tsx
@@ -463,53 +463,52 @@ export default function EditContactDialog({ contact, isOpen, onClose, onSave, on
             />
           </div>
 
-              <DialogFooter className="flex justify-between">
-                <div>
-                  {onDelete && (
-                    <AlertDialog>
-                      <AlertDialogTrigger asChild>
-                        <Button 
-                          type="button" 
-                          variant="destructive" 
-                          disabled={loading || deleteLoading}
+              <DialogFooter className="gap-2 sm:gap-0 sm:justify-between">
+                {onDelete && (
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="destructive"
+                        disabled={loading || deleteLoading}
+                        className="w-full sm:w-auto"
+                      >
+                        {deleteLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                        Delete QSO
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          Are you sure you want to delete this QSO with {contact?.callsign}? This action cannot be undone.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      {deleteError && (
+                        <Alert className="border-destructive/20 bg-destructive/10">
+                          <AlertCircle className="h-4 w-4" />
+                          <AlertDescription className="text-destructive">{deleteError}</AlertDescription>
+                        </Alert>
+                      )}
+                      <AlertDialogFooter>
+                        <AlertDialogCancel disabled={deleteLoading}>Cancel</AlertDialogCancel>
+                        <AlertDialogAction
+                          onClick={handleDelete}
+                          disabled={deleteLoading}
+                          className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
                         >
                           {deleteLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                           Delete QSO
-                        </Button>
-                      </AlertDialogTrigger>
-                      <AlertDialogContent>
-                        <AlertDialogHeader>
-                          <AlertDialogTitle>Are you sure?</AlertDialogTitle>
-                          <AlertDialogDescription>
-                            Are you sure you want to delete this QSO with {contact?.callsign}? This action cannot be undone.
-                          </AlertDialogDescription>
-                        </AlertDialogHeader>
-                        {deleteError && (
-                          <Alert className="border-destructive/20 bg-destructive/10">
-                            <AlertCircle className="h-4 w-4" />
-                            <AlertDescription className="text-destructive">{deleteError}</AlertDescription>
-                          </Alert>
-                        )}
-                        <AlertDialogFooter>
-                          <AlertDialogCancel disabled={deleteLoading}>Cancel</AlertDialogCancel>
-                          <AlertDialogAction 
-                            onClick={handleDelete}
-                            disabled={deleteLoading}
-                            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                          >
-                            {deleteLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                            Delete QSO
-                          </AlertDialogAction>
-                        </AlertDialogFooter>  
-                      </AlertDialogContent>
-                    </AlertDialog>
-                  )}
-                </div>
-                <div className="flex space-x-2">
-                  <Button type="button" variant="outline" onClick={onClose}>
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                )}
+                <div className="flex flex-col-reverse sm:flex-row gap-2 sm:gap-0 sm:space-x-2 sm:ml-auto">
+                  <Button type="button" variant="outline" onClick={onClose} className="w-full sm:w-auto">
                     Cancel
                   </Button>
-                  <Button type="submit" disabled={loading}>
+                  <Button type="submit" disabled={loading} className="w-full sm:w-auto">
                     {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                     Save Changes
                   </Button>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Plus, Search, ChevronDown } from 'lucide-react';
+import { Plus, Search, ChevronDown, Menu, X } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { BrandLockup } from '@/components/ui/brand-mark';
@@ -51,13 +51,18 @@ export default function Navbar({ actions }: NavbarProps) {
   // but no longer rendered — pages now use <PageHeader> for that.
   const { user } = useUser();
   const pathname = usePathname();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  useEffect(() => {
+    setMobileOpen(false);
+  }, [pathname]);
 
   const isActive = (href: string) =>
     href === '/' ? pathname === '/' : pathname?.startsWith(href);
 
   return (
     <header
-      className="sticky top-0 z-50 flex items-center gap-7 px-6 lg:px-8 py-4 border-b border-line"
+      className="sticky top-0 z-50 flex items-center gap-4 md:gap-7 px-4 sm:px-6 lg:px-8 py-4 border-b border-line"
       style={{
         background: 'rgb(from var(--bg) r g b / 0.72)',
         backdropFilter: 'saturate(140%) blur(14px)',
@@ -65,6 +70,16 @@ export default function Navbar({ actions }: NavbarProps) {
       }}
     >
       <BrandLockup href="/dashboard" />
+
+      <button
+        type="button"
+        aria-label={mobileOpen ? 'Close menu' : 'Open menu'}
+        aria-expanded={mobileOpen}
+        onClick={() => setMobileOpen((v) => !v)}
+        className="md:hidden ml-auto inline-grid place-items-center h-9 w-9 rounded-[8px] border border-line-hi bg-bg-2 text-fg cursor-pointer hover:bg-bg-3"
+      >
+        {mobileOpen ? <X className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
+      </button>
 
       <nav className="hidden md:flex items-center gap-1 ml-2">
         {PRIMARY_LINKS.map((link) => {
@@ -102,7 +117,29 @@ export default function Navbar({ actions }: NavbarProps) {
         </DropdownMenu>
       </nav>
 
-      <div className="ml-auto flex items-center gap-3">
+      {mobileOpen && (
+        <nav className="md:hidden absolute top-full left-0 right-0 bg-bg-1 border-b border-line p-3 flex flex-col gap-1 shadow-lg">
+          {[...PRIMARY_LINKS, ...MORE_LINKS].map((link) => {
+            const active = isActive(link.href);
+            return (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={cn(
+                  'px-3.5 py-3 rounded-[8px] text-[15px] transition-colors',
+                  active
+                    ? 'bg-accent/10 text-accent'
+                    : 'text-fg-1 hover:bg-white/5 hover:text-fg'
+                )}
+              >
+                {link.label}
+              </Link>
+            );
+          })}
+        </nav>
+      )}
+
+      <div className="flex items-center gap-2 sm:gap-3 md:ml-auto">
         {user?.callsign ? (
           <Chip variant="default" className="hidden sm:inline-flex">
             <Dot tone="ok" live />


### PR DESCRIPTION
## Summary

- Three-tier responsive treatment (mobile ≤640 / tablet 641–1024 / desktop >1024, matching Tailwind `sm` / `md` / `lg`) across the app shell and the three main pages.
- Hamburger menu in `Navbar.tsx` (`useState`-toggled, closes on route change) flattens primary + more links into a single mobile panel.
- The 7-column QSO log table on the dashboard renders as stacked per-QSO cards below `md` via a parallel `md:hidden` tree over the same `filteredContacts` — no changes to `<Table>` itself.

## What changed

- `components/Navbar.tsx` — mobile hamburger button, tighter px padding, mobile panel rendering both `PRIMARY_LINKS` and `MORE_LINKS`.
- `app/page.tsx` (landing) — hero CTAs stack `w-full sm:w-auto`; preview content grid drops to single column below `lg`; section padding scales with viewport.
- `app/dashboard/page.tsx` — page padding; hero (map + quick log) and log + DXpeditions grids drop at `lg`; band-activity strip becomes 4-col grid below `md`; toolbar wraps with search on its own row; mobile QSO card list via a small `MobileCardRow` helper.
- `app/new-contact/page.tsx` — page padding; outer layout single column below `xl`; callsign mega-input `text-[32px] sm:text-[56px]`; lookup card grid restructures with the Verified chip spanning columns on mobile; action footer reverses with Save QSO on top.

## Test plan

- [ ] `npm run dev`, open Chrome devtools device toolbar
- [ ] **iPhone SE (375 × 667)** on `/`, `/dashboard`, `/new-contact`:
  - no horizontal scroll on `<body>`
  - hamburger visible, tap opens vertical link panel
  - dashboard stat grid 2×2, band strip wraps 4-wide, log renders as cards (callsign prominent, 5 labeled rows)
  - new-contact form fields single column, callsign input legible
- [ ] **iPad portrait (768 × 1024)**: hamburger gone, full nav visible; hero/layout grids still single column (drop is at `lg`)
- [ ] **Desktop (1280 × 800)**: identical to current — no regressions
- [ ] `npm run lint && npm run typecheck && npm run build` — all clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)