### PR TITLE
fix(lotw): normalize CRLF to LF in tCERT body so LoTW accepts uploads

### DIFF
--- a/src/lib/lotw.ts
+++ b/src/lib/lotw.ts
@@ -300,11 +300,19 @@ function parseP12(buf: Buffer, password: string): ParsedP12 {
   const privateKeyPem = forge.pki.privateKeyToPem(keyBag.key);
   const certPem = forge.pki.certificateToPem(certBag.cert);
 
-  // Strip exactly the BEGIN/END markers; keep internal newlines unchanged
-  // (LoTW's parser expects multi-line PEM bodies).
+  // Strip exactly the BEGIN/END markers, keep internal newlines, and normalize
+  // CRLF to LF. node-forge emits PEM with \r\n (pem.js, util.js encode64), but
+  // wavelog's reference .tq8 is produced from PHP's openssl_x509_export which
+  // uses \n only. LoTW silently rejects the QSOs in a file whose tCERT body
+  // doesn't match TQSL's expected line-ending convention (the file is still
+  // queued for processing — the "<!-- .UPL. accepted -->" marker just means
+  // the multipart POST was received — but the processor drops everything
+  // before the "Last upload" timestamp moves).
   const certPemBody = certPem
     .replace(/-----BEGIN CERTIFICATE-----\s*/g, '')
     .replace(/-----END CERTIFICATE-----\s*/g, '')
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
     .trim();
 
   // ARRL embeds DXCC entity ID in a private extension (PrintableString).


### PR DESCRIPTION
## Summary

Almost certainly the reason K1AF's LoTW "Last upload" timestamp hasn't moved from 2025-07-28 despite every upload from this app reporting success since #185.

**What's happening:**

- `node-forge`'s `certificateToPem` produces PEM with `\r\n` line endings (`node_modules/node-forge/lib/pem.js:46,82,84` and `util.js:1602` — `encode64` wraps base64 at `maxline=64` with `\r\n`).
- The wavelog reference `.tq8` we're matching comes from PHP's `openssl_x509_export`, which uses `\n` only.
- So our `tCERT` block ships the certificate body with CRLF between base64 lines instead of LF. LoTW's queue processor silently rejects every QSO in the file.

**Why the upload looks like it succeeded:**

LoTW's upload endpoint replies `<!-- .UPL. accepted --> File queued for processing` as soon as the multipart POST is received — that marker means "your file is in our queue", not "we processed it". The queue worker runs later, parses the `.tq8`, and (in this case) drops everything because the cert body doesn't match the expected line-ending convention. Operator "Last upload" timestamp on Logbook Call Sign Activity doesn't move, and the cert holder gets a rejection email.

**Fix**

Collapse `\r\n` (and any stray `\r`) to `\n` in `certPemBody` after stripping the BEGIN/END markers, before emitting in `tCERT`.

This does NOT affect the per-QSO RSA-SHA1 signatures — those are over the canonical sign-string, not over the PEM. Only the cert body the LoTW parser ingests needs to match.

## Test plan

After deploying:
- [x] Run the SQL reset from #212 again (or just for new QSOs since last sync) to clear `lotw_qsl_sent='Y'`
- [ ] Trigger upload on `/lotw` → "Upload now"
- [ ] Wait 10-30 min for LoTW's queue, then check **Logbook Call Sign Activity** for K1AF — "Last upload" should now show today's UTC time, not 2025-07-28
- [ ] Open **Your QSOs** on LoTW → the new QSOs should appear
- [ ] Verify the cert-holder email got the LoTW processing confirmation instead of the rejection notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)