### PR TITLE
fix(lotw): confirmations never applied - duplicate qsl_lotw_date assignment (42601)

### DIFF
--- a/src/app/api/lotw/download/route.ts
+++ b/src/app/api/lotw/download/route.ts
@@ -37,7 +37,7 @@ export async function POST(request: NextRequest) {
       // For cron jobs, just verify station exists
       stationResult = await query(
         `SELECT s.id, s.callsign, s.lotw_username, s.lotw_password, s.user_id,
-                u.third_party_services
+                s.lotw_last_qsl_rcvd_date, u.third_party_services
          FROM stations s
          JOIN users u ON s.user_id = u.id
          WHERE s.id = $1`,
@@ -50,7 +50,7 @@ export async function POST(request: NextRequest) {
       }
       stationResult = await query(
         `SELECT s.id, s.callsign, s.lotw_username, s.lotw_password, s.user_id,
-                u.third_party_services
+                s.lotw_last_qsl_rcvd_date, u.third_party_services
          FROM stations s
          JOIN users u ON s.user_id = u.id
          WHERE s.id = $1 AND s.user_id = $2`,
@@ -125,9 +125,19 @@ export async function POST(request: NextRequest) {
         ['processing', downloadLogId]
       );
 
+      // Incremental fetch for scheduled runs: resume from the newest QSL date
+      // already applied (qso_qslsince filters by QSL date, not QSO date, so
+      // the local contacts query below must stay unfiltered by this date —
+      // confirmations can arrive for arbitrarily old QSOs).
+      let urlDateFrom = date_from;
+      if (!urlDateFrom && download_method !== 'manual' && station.lotw_last_qsl_rcvd_date) {
+        const last = station.lotw_last_qsl_rcvd_date;
+        urlDateFrom = last instanceof Date ? last.toISOString().split('T')[0] : String(last);
+      }
+
       // Build LoTW download URL
       const downloadUrl = buildLoTWDownloadUrl(lotwUsername, lotwPassword, {
-        dateFrom: date_from,
+        dateFrom: urlDateFrom,
         dateTo: date_to,
         ownCallsign: station.callsign,
       });
@@ -229,6 +239,9 @@ export async function POST(request: NextRequest) {
 
       let matchedCount = 0;
       let unmatchedCount = confirmations.length;
+      let failedCount = 0;
+      let firstApplyError: string | null = null;
+      const appliedQslDates: string[] = [];
 
       // Apply each confirmation: set LoTW QSL flags, enrich location fields
       // (state/county/CQZ/ITUZ/DXCC/country/grid/iota), and cross-flag QRZ
@@ -239,7 +252,6 @@ export async function POST(request: NextRequest) {
         // Build a dynamic UPDATE — only set fields LoTW returned non-empty.
         const sets: string[] = [
           'qsl_lotw = true',
-          `qsl_lotw_date = NOW()::date`,
           `lotw_qsl_rcvd = 'Y'`,
           'lotw_match_status = $1',
           'updated_at = NOW()',
@@ -276,28 +288,43 @@ export async function POST(request: NextRequest) {
         if (match.contact.qrz_qsl_sent === 'Y') {
           sets.push(`qrz_qsl_sent = 'M'`);
         }
-        // qsl_rcvd_date from LoTW is YYYY-MM-DD already.
+        // qsl_lotw_date is assigned exactly once — Postgres rejects an UPDATE
+        // that sets the same column twice. Prefer LoTW's own QSL date
+        // (YYYY-MM-DD already); fall back to today.
         if (conf.qsl_rcvd_date) {
           params.push(conf.qsl_rcvd_date);
           sets.push(`qsl_lotw_date = $${params.length}::date`);
+        } else {
+          sets.push('qsl_lotw_date = NOW()::date');
         }
 
         params.push(match.contact.id);
-        await query(
-          `UPDATE contacts SET ${sets.join(', ')} WHERE id = $${params.length}`,
-          params
-        );
-
-        matchedCount++;
-        unmatchedCount--;
+        try {
+          await query(
+            `UPDATE contacts SET ${sets.join(', ')} WHERE id = $${params.length}`,
+            params
+          );
+          matchedCount++;
+          unmatchedCount--;
+          if (conf.qsl_rcvd_date) appliedQslDates.push(conf.qsl_rcvd_date);
+        } catch (applyError) {
+          // Isolate per-row failures so one bad row can't discard the batch.
+          failedCount++;
+          const msg = applyError instanceof Error ? applyError.message : 'Unknown error';
+          if (!firstApplyError) firstApplyError = msg;
+          console.error(
+            `[LoTW Download] Failed to apply confirmation to contact ${match.contact.id}:`,
+            applyError
+          );
+        }
       }
 
       // Persist the most recent qsl_rcvd_date so the next download can use it
-      // as qso_qslsince for an incremental fetch.
-      if (matches.length > 0) {
-        const maxDate = matches
-          .map(m => m.confirmation.qsl_rcvd_date)
-          .filter((d): d is string => !!d)
+      // as qso_qslsince for an incremental fetch. Only consider confirmations
+      // that actually applied — advancing past a failed row would skip it on
+      // the next incremental run.
+      if (appliedQslDates.length > 0) {
+        const maxDate = appliedQslDates
           .sort()
           .pop();
         if (maxDate) {
@@ -310,14 +337,20 @@ export async function POST(request: NextRequest) {
         }
       }
 
-      // Update download log as completed
+      // Update download log as completed; surface partial apply failures so
+      // they are visible in the sync history instead of silently dropped.
+      const applyErrorMessage = failedCount > 0
+        ? `${failedCount} matched confirmation(s) failed to apply: ${firstApplyError}`
+        : null;
+
       await query(
-        `UPDATE lotw_download_logs 
-         SET status = 'completed', completed_at = NOW(), 
-             qso_count = $1, confirmations_found = $2, 
-             confirmations_matched = $3, confirmations_unmatched = $4
-         WHERE id = $5`,
-        [contacts.length, confirmations.length, matchedCount, unmatchedCount, downloadLogId]
+        `UPDATE lotw_download_logs
+         SET status = 'completed', completed_at = NOW(),
+             qso_count = $1, confirmations_found = $2,
+             confirmations_matched = $3, confirmations_unmatched = $4,
+             error_message = $5
+         WHERE id = $6`,
+        [contacts.length, confirmations.length, matchedCount, unmatchedCount, applyErrorMessage, downloadLogId]
       );
 
       const response: LotwDownloadResponse = {
@@ -325,7 +358,8 @@ export async function POST(request: NextRequest) {
         download_log_id: downloadLogId,
         confirmations_found: confirmations.length,
         confirmations_matched: matchedCount,
-        confirmations_unmatched: unmatchedCount
+        confirmations_unmatched: unmatchedCount,
+        ...(applyErrorMessage ? { error_message: applyErrorMessage } : {})
       };
 
       return NextResponse.json(response);

--- a/src/app/api/lotw/download/route.ts
+++ b/src/app/api/lotw/download/route.ts
@@ -290,13 +290,11 @@ export async function POST(request: NextRequest) {
         }
         // qsl_lotw_date is assigned exactly once — Postgres rejects an UPDATE
         // that sets the same column twice. Prefer LoTW's own QSL date
-        // (YYYY-MM-DD already); fall back to today.
-        if (conf.qsl_rcvd_date) {
-          params.push(conf.qsl_rcvd_date);
-          sets.push(`qsl_lotw_date = $${params.length}::date`);
-        } else {
-          sets.push('qsl_lotw_date = NOW()::date');
-        }
+        // (YYYY-MM-DD already); fall back to today (UTC) so the applied date
+        // still advances the incremental-download watermark below.
+        const qslDate = conf.qsl_rcvd_date || new Date().toISOString().slice(0, 10);
+        params.push(qslDate);
+        sets.push(`qsl_lotw_date = $${params.length}::date`);
 
         params.push(match.contact.id);
         try {
@@ -306,7 +304,7 @@ export async function POST(request: NextRequest) {
           );
           matchedCount++;
           unmatchedCount--;
-          if (conf.qsl_rcvd_date) appliedQslDates.push(conf.qsl_rcvd_date);
+          appliedQslDates.push(qslDate);
         } catch (applyError) {
           // Isolate per-row failures so one bad row can't discard the batch.
           failedCount++;


### PR DESCRIPTION
## Problem

"LoTW confirmations never come back." The bulk download route builds a dynamic `UPDATE contacts SET ...` that assigned `qsl_lotw_date` **twice** — seeded as `NOW()::date` and appended again with LoTW's `qsl_rcvd_date` (returned for nearly every confirmation when `qso_qsl=yes`). Postgres rejects multiple assignments to the same column in one UPDATE (error 42601), so the **first matched confirmation threw**, the outer catch marked the whole download `failed`, and every confirmation in the batch was discarded. Downloads have been silently failing whenever there was anything to apply.

## Fix

- Assign `qsl_lotw_date` exactly once: LoTW's own QSL date when present, else today.
- Per-row try/catch around each confirmation apply — one bad row can no longer zero out a batch. Failures are counted, logged with the contact id, and summarized in `lotw_download_logs.error_message` and the response.
- Advance the incremental cursor (`stations.lotw_last_qsl_rcvd_date`) only from confirmations that actually applied, and read it back as `qso_qslsince` for non-manual downloads — the column was maintained but never used, so cron downloads re-fetched the full history every run. (The QSL-since date is deliberately NOT applied to the local contacts filter: confirmations arrive for arbitrarily old QSOs.)

## Verification

- `npm run lint` / `npm run typecheck` / `npm run build` clean.
- First PR of the sync-reliability series (LoTW download fix → QRZ auto-sync rewrite → cron auth → unified hourly sync cron → sync activity UI → UTC parsing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
