### PR TITLE
fix(adif): import fields with an optional data-type indicator

### DIFF
--- a/src/lib/adif.ts
+++ b/src/lib/adif.ts
@@ -39,12 +39,19 @@ export function parseAdifRecords(content: string): AdifRecord[] {
 
 function parseSingleRecord(recordString: string): AdifRecord | null {
   const fields: { [key: string]: string } = {};
-  const fieldRegex = /<([^:>]+):(\d+)>([^<]*)/gi;
+  // ADIF field spec: <fieldname:length[:type]>data
+  // The optional data-type indicator (e.g. <QSO_DATE:8:D>, <TIME_ON:6:T>,
+  // <FREQ:8:N>) is emitted by WSJT-X, N1MM, Log4OM and most modern loggers.
+  // The previous regex required '>' immediately after the length, so any
+  // type-qualified field was silently dropped on import — and when that field
+  // was QSO_DATE or TIME_ON the whole QSO was rejected as "missing date/time".
+  // We now skip an optional ':type' segment; name + length still drive parsing.
+  const fieldRegex = /<([^:>]+):(\d+)(?::[^>]*)?>([^<]*)/gi;
   let match;
 
   while ((match = fieldRegex.exec(recordString)) !== null) {
     const fieldName = match[1].toLowerCase();
-    const length = parseInt(match[2]);
+    const length = parseInt(match[2], 10);
     let value = match[3];
 
     if (value.length > length) {

--- a/tests/adif-parse.spec.ts
+++ b/tests/adif-parse.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+import { parseAdifRecords } from '@/lib/adif';
+
+// Pure-function tests for the ADIF parser. These exercise parseAdifRecords()
+// directly (no browser/DB needed) and guard the interop bug where fields
+// carrying an optional data-type indicator were silently dropped on import.
+
+test.describe('parseAdifRecords', () => {
+  test('parses fields with an optional data-type indicator', () => {
+    // WSJT-X / N1MM / Log4OM style: <QSO_DATE:8:D>, <TIME_ON:6:T>, <FREQ:8:N>
+    const adif =
+      '<call:4>W1AW<qso_date:8:D>20240115<time_on:6:T>123456' +
+      '<mode:3>SSB<freq:8:N>14.07400<eor>';
+
+    const [record] = parseAdifRecords(adif);
+
+    expect(record.fields).toMatchObject({
+      call: 'W1AW',
+      qso_date: '20240115',
+      time_on: '123456',
+      mode: 'SSB',
+      freq: '14.07400',
+    });
+  });
+
+  test('still parses fields without a type indicator', () => {
+    const adif = '<call:4>K1XX<qso_date:8>20231231<time_on:4>2359<eor>';
+
+    const [record] = parseAdifRecords(adif);
+
+    expect(record.fields).toMatchObject({
+      call: 'K1XX',
+      qso_date: '20231231',
+      time_on: '2359',
+    });
+  });
+
+  test('clips an over-long value to its declared length', () => {
+    // Declared length 4 but 6 characters of data before <eor>.
+    const adif = '<call:4>K1XXYZ<eor>';
+
+    const [record] = parseAdifRecords(adif);
+
+    expect(record.fields.call).toBe('K1XX');
+  });
+
+  test('strips the header and splits multiple records', () => {
+    const adif =
+      'Some header\n<programid:7>Nextlog<eoh>\n' +
+      '<call:5>W1AW<qso_date:8:D>20240101<time_on:4:T>1200<eor>\n' +
+      '<call:5>K5ZZ<qso_date:8:D>20240102<time_on:4:T>1300<eor>\n';
+
+    const records = parseAdifRecords(adif);
+
+    expect(records).toHaveLength(2);
+    expect(records[0].fields.call).toBe('W1AW');
+    expect(records[1].fields.call).toBe('K5ZZ');
+    // The header's <programid> must not leak into the first QSO record.
+    expect(records[0].fields.programid).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

ADIF is a length-prefixed format where each field is written as
`<name:length>data`, with an **optional** data-type indicator:
`<name:length:type>data`. Nextlog's import parser used the regex
`/<([^:>]+):(\d+)>([^<]*)/` which requires `>` to come immediately after
the length — so any field carrying a `:type` segment failed to match and
was **silently dropped**.

This is not an edge case. WSJT-X, N1MM Logger and Log4OM all emit type
indicators routinely, especially on the fields that matter most:

- `<QSO_DATE:8:D>`
- `<TIME_ON:6:T>`
- `<FREQ:8:N>`

Because `insertAdifRecord()` rejects any record with a missing
`qso_date`/`time_on` (`"Missing date/time for ..."`), dropping those two
fields meant **entire QSOs — often entire log files — failed to import**
from the most popular logging software in the hobby.

## Solution

Make the field regex tolerate (and skip) the optional `:type` segment:

```diff
-  const fieldRegex = /<([^:>]+):(\d+)>([^<]*)/gi;
+  const fieldRegex = /<([^:>]+):(\d+)(?::[^>]*)?>([^<]*)/gi;
```

The value-extraction and length-clipping logic is unchanged, so behaviour
for type-less fields is identical — this is a strict superset of what
parsed before, fully backwards compatible. `parseAdifRecords()` /
`insertAdifRecord()` are shared by the UI import (`/api/adif/import`) and
the wavelog-compatible `/api/qso` endpoint, so both benefit.

## Testing

- Added `tests/adif-parse.spec.ts` — pure-function tests for
  `parseAdifRecords` covering: type-qualified fields, type-less fields,
  over-long value clipping, and header stripping + multi-record splitting.
  The type-indicator test fails against the old regex and passes with the
  fix.
- `npm run typecheck` — clean
- `npm run lint` (on changed files) — clean
- `npm run build` — compiles successfully

## Future follow-up

- Length-prefixed values that legitimately contain `<`/`>` (e.g. some
  comment fields) are still truncated at the first `<`, matching the
  prior behaviour. A fully length-authoritative reader could handle that,
  but it carries a small risk with malformed over-declared lengths, so it
  was deliberately left out of this focused fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)