### PR TITLE
fix(adif): derive band for 60M/4M/1.25M/LF/microwave on frequency import

### DIFF
--- a/src/lib/adif.ts
+++ b/src/lib/adif.ts
@@ -196,9 +196,17 @@ function adifDateTimeToUtc(adifDate: string, adifTime: string): Date | null {
   }
 }
 
+// Map an operating frequency (MHz) to its amateur band. Ranges follow the ADIF
+// Band Enumeration rather than any single region's allocation, so an import from
+// a foreign logger lands on the right band regardless of where the QSO was made.
+// The names mirror the uppercase form used across the app (charts, filters,
+// export); anything outside a known band falls back to 'OTHER'.
 export function frequencyToBand(frequency: number): string {
+  if (frequency >= 0.1357 && frequency <= 0.1378) return '2200M';
+  if (frequency >= 0.472 && frequency <= 0.479) return '630M';
   if (frequency >= 1.8 && frequency <= 2.0) return '160M';
   if (frequency >= 3.5 && frequency <= 4.0) return '80M';
+  if (frequency >= 5.06 && frequency <= 5.45) return '60M';
   if (frequency >= 7.0 && frequency <= 7.3) return '40M';
   if (frequency >= 10.1 && frequency <= 10.15) return '30M';
   if (frequency >= 14.0 && frequency <= 14.35) return '20M';
@@ -207,10 +215,13 @@ export function frequencyToBand(frequency: number): string {
   if (frequency >= 24.89 && frequency <= 24.99) return '12M';
   if (frequency >= 28.0 && frequency <= 29.7) return '10M';
   if (frequency >= 50.0 && frequency <= 54.0) return '6M';
+  if (frequency >= 70.0 && frequency <= 71.0) return '4M';
   if (frequency >= 144.0 && frequency <= 148.0) return '2M';
+  if (frequency >= 222.0 && frequency <= 225.0) return '1.25M';
   if (frequency >= 420.0 && frequency <= 450.0) return '70CM';
   if (frequency >= 902.0 && frequency <= 928.0) return '33CM';
   if (frequency >= 1240.0 && frequency <= 1300.0) return '23CM';
+  if (frequency >= 2300.0 && frequency <= 2450.0) return '13CM';
 
   return 'OTHER';
 }

--- a/tests/frequency-to-band.spec.ts
+++ b/tests/frequency-to-band.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+import { frequencyToBand } from '@/lib/adif';
+
+// Pure-function tests for the ADIF-import frequency→band fallback. These guard
+// the interop gap where an imported QSO whose <band> field was absent but which
+// carried a <freq> on a band the mapper didn't know (60M, 4M, 1.25M, the LF/MF
+// bands, 13CM) was stored as 'OTHER' — invisible to band filters and charts.
+
+test.describe('frequencyToBand', () => {
+  test('maps the classic HF bands', () => {
+    expect(frequencyToBand(1.840)).toBe('160M');
+    expect(frequencyToBand(3.573)).toBe('80M');
+    expect(frequencyToBand(7.074)).toBe('40M');
+    expect(frequencyToBand(10.136)).toBe('30M');
+    expect(frequencyToBand(14.074)).toBe('20M');
+    expect(frequencyToBand(18.100)).toBe('17M');
+    expect(frequencyToBand(21.074)).toBe('15M');
+    expect(frequencyToBand(24.915)).toBe('12M');
+    expect(frequencyToBand(28.074)).toBe('10M');
+  });
+
+  test('maps 60M — the band the importer previously missed', () => {
+    // WSJT-X FT8 watering hole on 60M in the US channelised sub-band.
+    expect(frequencyToBand(5.3574)).toBe('60M');
+    expect(frequencyToBand(5.107)).toBe('60M');
+  });
+
+  test('maps the LF/MF digital bands', () => {
+    expect(frequencyToBand(0.1360)).toBe('2200M');
+    expect(frequencyToBand(0.4742)).toBe('630M');
+  });
+
+  test('maps the VHF/UHF bands', () => {
+    expect(frequencyToBand(50.313)).toBe('6M');
+    expect(frequencyToBand(70.154)).toBe('4M');
+    expect(frequencyToBand(144.174)).toBe('2M');
+    expect(frequencyToBand(222.100)).toBe('1.25M');
+    expect(frequencyToBand(432.100)).toBe('70CM');
+    expect(frequencyToBand(1296.100)).toBe('23CM');
+  });
+
+  test('maps the microwave bands the app charts', () => {
+    expect(frequencyToBand(915.0)).toBe('33CM');
+    expect(frequencyToBand(2320.0)).toBe('13CM');
+  });
+
+  test('falls back to OTHER for out-of-band frequencies', () => {
+    expect(frequencyToBand(4.5)).toBe('OTHER');
+    expect(frequencyToBand(100.0)).toBe('OTHER');
+  });
+});


### PR DESCRIPTION
## Problem

When an ADIF record is imported with a `<freq>` but no `<band>` field (common from WSJT-X, JTDX, and other loggers), the importer derives the band from the frequency via `frequencyToBand()` in `src/lib/adif.ts`. That helper only knew a subset of the amateur bands, so QSOs on several bands fell through to `'OTHER'`:

- **60M** — the FT8/digital watering hole, and a real everyday gap
- **4M**, **1.25M**
- **2200M** / **630M** (LF/MF digital)
- **13CM**

Those QSOs were then invisible to band filters and charts — even though the rest of the app already recognises these bands. The manual-entry form (`new-contact/page.tsx`) already handled 60M/1.25M, so the import path was the odd one out.

## Solution

Extend `frequencyToBand()` to cover the full band set, using **ADIF Band Enumeration** ranges rather than any one region's allocation, so imports from foreign loggers still land on the correct band. Names keep the existing uppercase form used across charts, filters, and export (`'60M'`, `'4M'`, `'1.25M'`, `'2200M'`, `'630M'`, `'13CM'`). Anything outside a known band still falls back to `'OTHER'`.

No behavior change for the bands that already mapped; this only fills in the missing ones. Backwards compatible.

## Testing

- Added `tests/frequency-to-band.spec.ts` — pure-function tests (same style as `adif-parse.spec.ts`) covering the classic HF, 60M, LF/MF, VHF/UHF, microwave, and `OTHER`-fallback cases. Confirmed they fail against the old mapper (returned `OTHER`) and pass after the change.
- Existing `adif-parse.spec.ts` suite: passes.
- `npm run typecheck`, `npm run lint`, `npm run build`: all clean.

## Follow-up (out of scope)

- `freqToBand()` in `src/app/new-contact/page.tsx` is a separate, US-centric copy used for quick manual entry. Consolidating the two into one shared, DB-free helper would remove the duplication — deferred to avoid pulling the server-only `@/lib/db` import chain into a client component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)