### PR TITLE
fix(adif): round-trip satellite and IOTA fields on import/export

### DIFF
--- a/src/app/api/adif/export/route.ts
+++ b/src/app/api/adif/export/route.ts
@@ -55,9 +55,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
              c.rst_sent, c.rst_received, c.qth, c.grid_locator, c.notes, 
              c.latitude, c.longitude, c.country, c.dxcc, c.cont, c.cqz, c.ituz, 
              c.state, c.cnty, c.qsl_rcvd, c.qsl_sent, c.qsl_via, c.eqsl_qsl_rcvd, 
-             c.eqsl_qsl_sent, c.lotw_qsl_rcvd, c.lotw_qsl_sent, c.qso_date_off, 
-             c.time_off, c.operator, c.distance,
-             s.callsign as station_callsign, s.grid_locator as my_gridsquare, 
+             c.eqsl_qsl_sent, c.lotw_qsl_rcvd, c.lotw_qsl_sent, c.qso_date_off,
+             c.time_off, c.operator, c.distance, c.prop_mode, c.sat_name,
+             c.band_rx, c.freq_rx, c.iota,
+             s.callsign as station_callsign, s.grid_locator as my_gridsquare,
              s.city as my_city, s.state_province as my_state, s.country as my_country,
              s.dxcc_entity_code as my_dxcc, s.itu_zone as my_itu_zone, 
              s.cq_zone as my_cq_zone, s.power_watts as tx_pwr

--- a/src/lib/adif.ts
+++ b/src/lib/adif.ts
@@ -124,6 +124,18 @@ export async function insertAdifRecord(
     qsoDateOff = adifDateTimeToUtc(fields.qso_date_off, fields.time_off);
   }
 
+  // Satellite / split receive frequency → band fallback, mirroring the freq
+  // handling above so a satellite QSO that only carries FREQ_RX still lands on
+  // the right receive band.
+  let freqRx: number | null = null;
+  let bandRx = fields.band_rx || '';
+  if (fields.freq_rx) {
+    freqRx = parseFloat(fields.freq_rx);
+    if (!bandRx && freqRx) {
+      bandRx = frequencyToBand(freqRx);
+    }
+  }
+
   const values = [
     userId,
     stationId,
@@ -158,6 +170,11 @@ export async function insertAdifRecord(
     qsoDateOff ? qsoDateOff.toISOString().split('T')[1].split('.')[0] : null,
     fields.operator || null,
     fields.distance ? parseFloat(fields.distance) : null,
+    fields.prop_mode ? fields.prop_mode.toUpperCase() : null,
+    fields.sat_name ? fields.sat_name.toUpperCase() : null,
+    bandRx || null,
+    freqRx,
+    fields.iota ? fields.iota.toUpperCase() : null,
   ];
 
   await query(
@@ -166,10 +183,10 @@ export async function insertAdifRecord(
       rst_sent, rst_received, qth, grid_locator, notes, latitude, longitude,
       country, dxcc, cont, cqz, ituz, state, cnty, qsl_rcvd, qsl_sent, qsl_via,
       eqsl_qsl_rcvd, eqsl_qsl_sent, lotw_qsl_rcvd, lotw_qsl_sent, qso_date_off,
-      time_off, operator, distance
+      time_off, operator, distance, prop_mode, sat_name, band_rx, freq_rx, iota
     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
              $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29,
-             $30, $31, $32, $33)`,
+             $30, $31, $32, $33, $34, $35, $36, $37, $38)`,
     values,
   );
 
@@ -232,6 +249,14 @@ export interface AdifExportContact {
   time_off?: string | null;
   operator?: string | null;
   distance?: number | null;
+  // Satellite / split-operation and IOTA fields. These are stored on every
+  // contact but were previously dropped on export, so satellite QSOs lost their
+  // bird/propagation identity and IOTA references never round-tripped.
+  prop_mode?: string | null;
+  sat_name?: string | null;
+  band_rx?: string | null;
+  freq_rx?: number | null;
+  iota?: string | null;
   // Station ("my") fields.
   station_callsign?: string | null;
   my_gridsquare?: string | null;
@@ -338,6 +363,14 @@ export function generateAdif(contacts: AdifExportContact[]): string {
     record += adifField('time_off', contact.time_off ? contact.time_off.replace(/:/g, '') : contact.time_off);
     record += adifField('operator', contact.operator);
     record += adifField('distance', contact.distance);
+
+    // Satellite / split-operation and IOTA fields. Designators (SAT, SO-50,
+    // NA-001) and bands are conventionally uppercase, matching band/gridsquare.
+    record += adifField('prop_mode', contact.prop_mode ? contact.prop_mode.toUpperCase() : contact.prop_mode);
+    record += adifField('sat_name', contact.sat_name ? contact.sat_name.toUpperCase() : contact.sat_name);
+    record += adifField('band_rx', contact.band_rx ? contact.band_rx.toUpperCase() : contact.band_rx);
+    record += adifField('freq_rx', contact.freq_rx);
+    record += adifField('iota', contact.iota ? contact.iota.toUpperCase() : contact.iota);
 
     record += '<eor>\n\n';
     records += record;

--- a/tests/adif-generate.spec.ts
+++ b/tests/adif-generate.spec.ts
@@ -129,4 +129,46 @@ test.describe('generateAdif', () => {
     expect(adif).toContain('<qsl_rcvd:1>Y');
     expect(adif).toContain('<lotw_qsl_rcvd:1>Y');
   });
+
+  // Satellite and IOTA data is stored on every contact but used to be dropped on
+  // export, so a satellite QSO lost its bird/propagation identity (breaking LoTW
+  // satellite awards) and IOTA references never round-tripped. Guard that these
+  // survive export, uppercased like other designators.
+  test('includes satellite, split and IOTA fields', () => {
+    const adif = generateAdif([
+      baseContact({
+        prop_mode: 'sat',
+        sat_name: 'so-50',
+        band_rx: '70cm',
+        freq_rx: 435.795,
+        iota: 'na-001',
+      }),
+    ]);
+
+    expect(adif).toContain('<prop_mode:3>SAT');
+    expect(adif).toContain('<sat_name:5>SO-50');
+    expect(adif).toContain('<band_rx:4>70CM');
+    expect(adif).toContain('<freq_rx:7>435.795');
+    expect(adif).toContain('<iota:6>NA-001');
+  });
+
+  test('round-trips satellite/IOTA fields back through the parser', () => {
+    const adif = generateAdif([
+      baseContact({
+        prop_mode: 'SAT',
+        sat_name: 'RS-44',
+        band_rx: '2M',
+        freq_rx: 435.01,
+        iota: 'EU-005',
+      }),
+    ]);
+
+    const [record] = parseAdifRecords(adif);
+
+    expect(record.fields.prop_mode).toBe('SAT');
+    expect(record.fields.sat_name).toBe('RS-44');
+    expect(record.fields.band_rx).toBe('2M');
+    expect(record.fields.freq_rx).toBe('435.01');
+    expect(record.fields.iota).toBe('EU-005');
+  });
 });


### PR DESCRIPTION
## Problem

Every contact row carries `prop_mode`, `sat_name`, `band_rx`, `freq_rx` and `iota` columns, but the ADIF import/export path ignored all five:

- **Satellite QSOs lost their identity on export.** A satellite contact exported from Nextlog contained no `PROP_MODE=SAT`, `SAT_NAME`, `FREQ_RX` or `BAND_RX`, so LoTW/eQSL couldn't credit it toward satellite awards and downstream loggers (GridTracker, SatPC32, N1MM) saw a bare terrestrial QSO.
- **IOTA references never round-tripped.** Island-on-the-Air chasers who imported or entered an `IOTA` reference lost it the moment they re-exported.
- **Import silently dropped the same fields**, so even an ADIF file that *did* carry satellite/IOTA data was flattened on the way in.

## Solution

Extend the shared ADIF serializer/parser used by every import and export path:

- `generateAdif()` now emits `PROP_MODE`, `SAT_NAME`, `BAND_RX`, `FREQ_RX` and `IOTA`. Designators and bands are uppercased to match the existing `BAND`/`GRIDSQUARE` handling.
- `insertAdifRecord()` persists the same five fields on import, and derives `BAND_RX` from `FREQ_RX` when only the receive frequency is present — mirroring the existing `FREQ → BAND` fallback so satellite ops who send just the downlink frequency still land on the right receive band.
- `AdifExportContact` gains the five typed fields.
- `/api/adif/export` adds the columns to its explicit `SELECT`. The search-results export (`/api/contacts/search?export=true`) already uses `SELECT *`, so it inherits them automatically.

No schema change — the columns already exist. Fully backwards compatible: contacts without these fields export exactly as before (empty values are omitted by `adifField`).

## Testing

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run build` — succeeds
- `npx playwright test adif-generate adif-parse` — **16 passed**, including two new cases:
  - satellite/split/IOTA fields are emitted and uppercased (`<prop_mode:3>SAT`, `<sat_name:5>SO-50`, `<band_rx:4>70CM`, `<freq_rx:7>435.795`, `<iota:6>NA-001`)
  - the fields survive a generate → parse round trip

## Future follow-up

- `insertAdifRecord` covers the import mapping but is DB-backed, so it isn't unit-tested here; an integration test against a seeded DB would guard the round trip end-to-end.
- The new-contact / edit-contact UI forms don't yet expose satellite/IOTA inputs — a natural next step now that the storage and interchange path is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)