### PR TITLE
feat(logging): show live distance & bearing when logging a contact

### DIFF
--- a/src/app/new-contact/page.tsx
+++ b/src/app/new-contact/page.tsx
@@ -37,6 +37,7 @@ import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
 import { frequencyToBand, AMATEUR_BANDS } from '@/lib/bands';
+import { gridToLatLon, distanceKm, bearingDeg, compassPoint, kmToMiles } from '@/lib/grid';
 
 void _PageHeader;
 
@@ -442,6 +443,7 @@ export default function NewContactPage() {
           grid_locator: formData.gridLocator,
           latitude: formData.latitude,
           longitude: formData.longitude,
+          distance: pathInfo ? Math.round(pathInfo.km) : undefined,
           frequency: parseFloat(formData.frequency),
           power: formData.power ? parseFloat(formData.power) : undefined,
           datetime: new Date(formData.datetime).toISOString(),
@@ -479,6 +481,28 @@ export default function NewContactPage() {
   }, [formData.datetime]);
 
   const station = stations.find((s) => s.id.toString() === selectedStationId);
+
+  // Distance and bearing from the operator's home grid to the contact — the
+  // "how far, which way" readout hams expect while logging. Prefers the
+  // contact's explicit coordinates (from a QRZ lookup) and falls back to the
+  // grid square typed into the form; renders nothing until both endpoints
+  // resolve, so a half-typed grid never shows a bogus reading.
+  const pathInfo = (() => {
+    const from = currentUser?.grid_locator
+      ? gridToLatLon(currentUser.grid_locator)
+      : null;
+    const to =
+      formData.latitude !== undefined && formData.longitude !== undefined
+        ? { lat: formData.latitude, lon: formData.longitude }
+        : formData.gridLocator
+          ? gridToLatLon(formData.gridLocator)
+          : null;
+    if (!from || !to) return null;
+    return {
+      km: distanceKm(from.lat, from.lon, to.lat, to.lon),
+      bearing: bearingDeg(from.lat, from.lon, to.lat, to.lon),
+    };
+  })();
 
   return (
     <div className="min-h-screen">
@@ -944,6 +968,32 @@ export default function NewContactPage() {
                     user={currentUser}
                     height="240px"
                   />
+                  {pathInfo ? (
+                    <dl className="mt-4 grid grid-cols-2 gap-3">
+                      <div className="flex flex-col gap-0.5">
+                        <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+                          Distance
+                        </dt>
+                        <dd className="font-mono text-lg font-semibold tabular-nums">
+                          {Math.round(pathInfo.km).toLocaleString()} km
+                          <span className="ml-1.5 text-sm font-normal text-muted-foreground">
+                            {Math.round(kmToMiles(pathInfo.km)).toLocaleString()} mi
+                          </span>
+                        </dd>
+                      </div>
+                      <div className="flex flex-col gap-0.5">
+                        <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+                          Bearing
+                        </dt>
+                        <dd className="font-mono text-lg font-semibold tabular-nums">
+                          {Math.round(pathInfo.bearing)}°
+                          <span className="ml-1.5 text-sm font-normal text-muted-foreground">
+                            {compassPoint(pathInfo.bearing)}
+                          </span>
+                        </dd>
+                      </div>
+                    </dl>
+                  ) : null}
                 </div>
               </Card>
 

--- a/src/lib/grid.ts
+++ b/src/lib/grid.ts
@@ -1,0 +1,124 @@
+// Maidenhead grid ↔ coordinate math plus great-circle distance/bearing — the
+// shared source of truth for turning a grid square (or a lat/lon pair) into the
+// "how far, which way" readout operators expect while logging.
+//
+// Like @/lib/bands this module is intentionally free of server-only imports
+// (no `pg`, no db pool) so the logging forms can pull it into the browser
+// bundle without dragging the database driver along.
+
+export interface LatLon {
+  lat: number;
+  lon: number;
+}
+
+const GRID_RE = /^[A-R]{2}[0-9]{2}([A-X]{2})?$/;
+
+// True for a well-formed 4- or 6-character Maidenhead locator (case-insensitive).
+export function isValidGrid(grid: string): boolean {
+  return GRID_RE.test(grid.trim().toUpperCase());
+}
+
+// Convert a Maidenhead locator to the latitude/longitude of the *center* of the
+// square (4-char) or subsquare (6-char). Returns null for anything that isn't a
+// valid locator. Centering matches @/components/ContactLocationMap so the map
+// pin and the distance readout agree.
+export function gridToLatLon(grid: string): LatLon | null {
+  const g = grid.trim().toUpperCase();
+  if (!GRID_RE.test(g)) return null;
+
+  const lonField = g.charCodeAt(0) - 65; // A–R → 0–17, 20° wide
+  const latField = g.charCodeAt(1) - 65; // A–R → 0–17, 10° tall
+  const lonSquare = Number(g[2]); // 0–9, 2° wide
+  const latSquare = Number(g[3]); // 0–9, 1° tall
+
+  let lon = -180 + lonField * 20 + lonSquare * 2;
+  let lat = -90 + latField * 10 + latSquare * 1;
+
+  if (g.length === 6) {
+    const lonSub = g.charCodeAt(4) - 65; // A–X → 0–23, 5' wide
+    const latSub = g.charCodeAt(5) - 65; // A–X → 0–23, 2.5' tall
+    lon += lonSub * (2 / 24) + 1 / 24; // + half a subsquare to center
+    lat += latSub * (1 / 24) + 1 / 48;
+  } else {
+    lon += 1; // + half a square (2°) to center
+    lat += 0.5; // + half a square (1°) to center
+  }
+
+  return { lat, lon };
+}
+
+const toRad = (deg: number): number => (deg * Math.PI) / 180;
+const toDeg = (rad: number): number => (rad * 180) / Math.PI;
+
+// Great-circle distance in kilometers between two points (haversine, R = 6371km).
+export function distanceKm(
+  lat1: number,
+  lon1: number,
+  lat2: number,
+  lon2: number
+): number {
+  const R = 6371;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+// Initial great-circle bearing from point 1 to point 2, in degrees 0–360
+// (0 = due north, 90 = east). This is the heading to point an antenna.
+export function bearingDeg(
+  lat1: number,
+  lon1: number,
+  lat2: number,
+  lon2: number
+): number {
+  const phi1 = toRad(lat1);
+  const phi2 = toRad(lat2);
+  const dLon = toRad(lon2 - lon1);
+  const y = Math.sin(dLon) * Math.cos(phi2);
+  const x =
+    Math.cos(phi1) * Math.sin(phi2) -
+    Math.sin(phi1) * Math.cos(phi2) * Math.cos(dLon);
+  return (toDeg(Math.atan2(y, x)) + 360) % 360;
+}
+
+const COMPASS_POINTS = [
+  'N', 'NNE', 'NE', 'ENE', 'E', 'ESE', 'SE', 'SSE',
+  'S', 'SSW', 'SW', 'WSW', 'W', 'WNW', 'NW', 'NNW',
+] as const;
+
+// 16-point compass label for a bearing in degrees, e.g. 45 → 'NE'.
+export function compassPoint(bearing: number): string {
+  const idx = Math.round((((bearing % 360) + 360) % 360) / 22.5) % 16;
+  return COMPASS_POINTS[idx];
+}
+
+export interface PathInfo {
+  distanceKm: number;
+  bearingDeg: number;
+  compass: string;
+}
+
+// Distance/bearing between two Maidenhead locators. Returns null unless both
+// parse — so a half-typed grid in the logging form simply shows nothing rather
+// than a bogus reading.
+export function gridPath(from: string, to: string): PathInfo | null {
+  const a = gridToLatLon(from);
+  const b = gridToLatLon(to);
+  if (!a || !b) return null;
+  const bearing = bearingDeg(a.lat, a.lon, b.lat, b.lon);
+  return {
+    distanceKm: distanceKm(a.lat, a.lon, b.lat, b.lon),
+    bearingDeg: bearing,
+    compass: compassPoint(bearing),
+  };
+}
+
+const KM_PER_MILE = 1.609344;
+
+// Kilometers → statute miles (US operators log distance in miles as often as km).
+export function kmToMiles(km: number): number {
+  return km / KM_PER_MILE;
+}

--- a/src/models/Contact.ts
+++ b/src/models/Contact.ts
@@ -67,6 +67,7 @@ export class Contact {
     grid_locator?: string;
     latitude?: number;
     longitude?: number;
+    distance?: number;
     notes?: string;
   }): Promise<ContactData> {
     const {
@@ -84,18 +85,19 @@ export class Contact {
       grid_locator,
       latitude,
       longitude,
+      distance,
       notes
     } = contactData;
-    
+
     const sql = `
       INSERT INTO contacts (
         user_id, station_id, callsign, name, frequency, mode, band, datetime,
-        rst_sent, rst_received, qth, grid_locator, latitude, longitude, notes
+        rst_sent, rst_received, qth, grid_locator, latitude, longitude, distance, notes
       )
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
       RETURNING *
     `;
-    
+
     const result = await query(sql, [
       user_id,
       station_id || null,
@@ -111,6 +113,7 @@ export class Contact {
       grid_locator ? grid_locator.toUpperCase().trim() : null,
       latitude || null,
       longitude || null,
+      distance ?? null,
       notes ? notes.trim() : null
     ]);
     

--- a/tests/grid.spec.ts
+++ b/tests/grid.spec.ts
@@ -1,0 +1,133 @@
+import { test, expect } from '@playwright/test';
+import {
+  isValidGrid,
+  gridToLatLon,
+  distanceKm,
+  bearingDeg,
+  compassPoint,
+  gridPath,
+  kmToMiles,
+} from '@/lib/grid';
+
+// Pure-function tests for the Maidenhead grid / great-circle math that powers
+// the distance-and-bearing readout on the logging form. Values are checked
+// against known references (grid square centers, cardinal bearings, one-degree
+// equatorial arc) with tolerances that allow for the great-circle model.
+
+test.describe('isValidGrid', () => {
+  test('accepts 4- and 6-character locators, case-insensitively', () => {
+    expect(isValidGrid('FN31')).toBe(true);
+    expect(isValidGrid('FN31pr')).toBe(true);
+    expect(isValidGrid('io91')).toBe(true);
+    expect(isValidGrid(' JN58 ')).toBe(true);
+  });
+
+  test('rejects malformed locators', () => {
+    expect(isValidGrid('')).toBe(false);
+    expect(isValidGrid('F1')).toBe(false); // too short
+    expect(isValidGrid('SN31')).toBe(false); // field letter past R
+    expect(isValidGrid('FN31YZ')).toBe(false); // subsquare past X
+    expect(isValidGrid('FNXY')).toBe(false); // square must be digits
+    expect(isValidGrid('FN31p')).toBe(false); // odd length
+  });
+});
+
+test.describe('gridToLatLon', () => {
+  test('returns the center of a 4-character square', () => {
+    // JJ00 straddles the prime meridian / equator origin of the grid; its
+    // center sits half a square (1° lon, 0.5° lat) up from the corner.
+    expect(gridToLatLon('JJ00')).toEqual({ lat: 0.5, lon: 1 });
+  });
+
+  test('places well-known squares near their real cities', () => {
+    const fn31 = gridToLatLon('FN31');
+    expect(fn31).not.toBeNull();
+    expect(fn31!.lat).toBeCloseTo(41.5, 5); // Connecticut
+    expect(fn31!.lon).toBeCloseTo(-73, 5);
+
+    const io91 = gridToLatLon('IO91');
+    expect(io91!.lat).toBeCloseTo(51.5, 5); // London
+    expect(io91!.lon).toBeCloseTo(-1, 5);
+  });
+
+  test('6-character locator refines within its parent square', () => {
+    const sub = gridToLatLon('FN31pr');
+    expect(sub).not.toBeNull();
+    // Still inside FN31 (lat 41–42, lon -74…-72).
+    expect(sub!.lat).toBeGreaterThan(41);
+    expect(sub!.lat).toBeLessThan(42);
+    expect(sub!.lon).toBeGreaterThan(-74);
+    expect(sub!.lon).toBeLessThan(-72);
+  });
+
+  test('returns null for invalid input', () => {
+    expect(gridToLatLon('nope')).toBeNull();
+    expect(gridToLatLon('')).toBeNull();
+  });
+});
+
+test.describe('distanceKm', () => {
+  test('is zero for coincident points', () => {
+    expect(distanceKm(0, 0, 0, 0)).toBe(0);
+  });
+
+  test('matches a one-degree arc at the equator (~111 km)', () => {
+    expect(distanceKm(0, 0, 0, 1)).toBeCloseTo(111.19, 1);
+  });
+
+  test('is symmetric', () => {
+    const a = distanceKm(51.5, -1, 41.5, -73);
+    const b = distanceKm(41.5, -73, 51.5, -1);
+    expect(a).toBeCloseTo(b, 6);
+  });
+});
+
+test.describe('bearingDeg', () => {
+  test('resolves the four cardinal directions from the equator', () => {
+    expect(bearingDeg(0, 0, 10, 0)).toBeCloseTo(0, 5); // north
+    expect(bearingDeg(0, 0, 0, 10)).toBeCloseTo(90, 5); // east
+    expect(bearingDeg(0, 0, -10, 0)).toBeCloseTo(180, 5); // south
+    expect(bearingDeg(0, 0, 0, -10)).toBeCloseTo(270, 5); // west
+  });
+
+  test('always returns a value in [0, 360)', () => {
+    const b = bearingDeg(41.5, -73, 51.5, -1);
+    expect(b).toBeGreaterThanOrEqual(0);
+    expect(b).toBeLessThan(360);
+  });
+});
+
+test.describe('compassPoint', () => {
+  test('maps bearings to 16-point compass labels', () => {
+    expect(compassPoint(0)).toBe('N');
+    expect(compassPoint(45)).toBe('NE');
+    expect(compassPoint(90)).toBe('E');
+    expect(compassPoint(180)).toBe('S');
+    expect(compassPoint(270)).toBe('W');
+    expect(compassPoint(360)).toBe('N'); // wraps
+    expect(compassPoint(348.75)).toBe('N'); // rounds up to N
+  });
+});
+
+test.describe('gridPath', () => {
+  test('reports the transatlantic hop from Connecticut to London', () => {
+    // FN31 → IO91 is a classic east-coast-US to England path, ~5500 km NE.
+    const path = gridPath('FN31', 'IO91');
+    expect(path).not.toBeNull();
+    expect(path!.distanceKm).toBeGreaterThan(5000);
+    expect(path!.distanceKm).toBeLessThan(6000);
+    expect(path!.compass).toBe('NE');
+  });
+
+  test('returns null when either locator is invalid', () => {
+    expect(gridPath('FN31', 'nope')).toBeNull();
+    expect(gridPath('', 'IO91')).toBeNull();
+  });
+});
+
+test.describe('kmToMiles', () => {
+  test('converts kilometers to statute miles', () => {
+    expect(kmToMiles(1.609344)).toBeCloseTo(1, 6);
+    expect(kmToMiles(100)).toBeCloseTo(62.137, 2);
+  });
+});


### PR DESCRIPTION
## Problem

The Nextlog landing page promises operators "name, grid, DXCC, **distance and bearing** instantly" — but the logging form never actually computed distance or bearing. Worse, contacts logged through the form were persisted with a `NULL` `distance`; only ADIF-imported QSOs ever carried the value, so form-logged contacts exported an empty `<DISTANCE>` field and were invisible to any distance-based stat.

## Solution

Add a small, pure, client-safe Maidenhead + great-circle utility and wire it into the new-contact form.

**`src/lib/grid.ts`** (new, no server imports — safe for the browser bundle, mirroring `@/lib/bands`):
- `gridToLatLon(grid)` — centers a 4- or 6-character locator, using the exact centering `ContactLocationMap` already uses so the map pin and the readout agree.
- `distanceKm` (haversine, R=6371), `bearingDeg` (initial great-circle bearing, 0–360), `compassPoint` (16-point label), `gridPath` (grid→grid convenience), `kmToMiles`, `isValidGrid`.

**`src/app/new-contact/page.tsx`:**
- The **Path** card now shows the great-circle **distance** (km + mi) and **bearing** (degrees + compass point) from the operator's home grid to the contact. It updates live as the destination resolves — from a QRZ lookup's coordinates when available, falling back to the grid square typed into the form — and renders nothing until both endpoints resolve, so a half-typed grid never shows a bogus reading.
- The rounded distance is included in the create payload.

**`src/models/Contact.ts`:**
- `Contact.create` now accepts and persists `distance` (it was silently dropped before). The column already existed and is read by ADIF export, so form-logged contacts now round-trip a distance through export and are available to awards/stats.

## Testing

- **New:** `tests/grid.spec.ts` — 15 pure-function unit tests covering grid validation, square/subsquare centering (checked against real city locations), a zero-distance and a one-degree equatorial arc (~111 km), the four cardinal bearings, compass labeling, and a known FN31→IO91 transatlantic path (~5500 km, NE).
- `npm run typecheck` — clean
- `npm run lint` — clean (no new warnings)
- `npm run build` — succeeds
- Re-ran the existing pure-function specs (`bands`, `frequency-to-band`) alongside the new ones — all green.

## Notes / follow-up

- The "from" reference is the operator's home grid (`currentUser.grid_locator`), matching the Path map's origin. When no home grid is set, the readout is simply hidden.
- Backwards compatible: no schema change (the `distance` column already existed), no API-shape change beyond an additional optional `distance` field on the create body.
- Follow-up candidates: surface distance/bearing on the QuickLog dashboard card and in the edit-contact dialog, and recompute distance on grid edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)