### PR TITLE
fix(adif): export/import coordinates as standard ADIF LAT/LON

### DIFF
--- a/src/lib/adif.ts
+++ b/src/lib/adif.ts
@@ -142,6 +142,20 @@ export async function insertAdifRecord(
     }
   }
 
+  // Coordinates: standard ADIF LAT/LON are `XDDD MM.MMM` strings. Older Nextlog
+  // exports wrote raw decimal degrees under the non-standard lat_n/lon_w fields,
+  // so accept those as a fallback for round-tripping previously-exported files.
+  const latitude = fields.lat
+    ? adifCoordToDecimal(fields.lat)
+    : fields.lat_n
+      ? parseFloat(fields.lat_n)
+      : null;
+  const longitude = fields.lon
+    ? adifCoordToDecimal(fields.lon)
+    : fields.lon_w
+      ? parseFloat(fields.lon_w)
+      : null;
+
   const values = [
     userId,
     stationId,
@@ -156,8 +170,8 @@ export async function insertAdifRecord(
     fields.qth || null,
     fields.gridsquare || null,
     fields.notes || fields.comment || null,
-    fields.lat_n ? parseFloat(fields.lat_n) : null,
-    fields.lon_w ? parseFloat(fields.lon_w) : null,
+    latitude,
+    longitude,
     fields.country || null,
     fields.dxcc ? parseInt(fields.dxcc) : null,
     fields.cont || null,
@@ -197,6 +211,41 @@ export async function insertAdifRecord(
   );
 
   return { inserted: true, skipped: false };
+}
+
+/**
+ * Parse an ADIF "Location" value (`XDDD MM.MMM`, e.g. `N040 26.500`) into signed
+ * decimal degrees, or null if it doesn't match the spec. X is the hemisphere
+ * (N/S for latitude, E/W for longitude); southern/western hemispheres are
+ * negative. This is the format LoTW/TQSL, Cloudlog and N1MM emit for LAT/LON —
+ * the previous code read a non-standard `lat_n`/`lon_w` decimal field that no
+ * other logger produces, so imported coordinates were always dropped.
+ */
+export function adifCoordToDecimal(value: string): number | null {
+  const m = /^([NSEW])\s*(\d{1,3})\s+(\d+(?:\.\d+)?)$/i.exec(value.trim());
+  if (!m) return null;
+  const hemi = m[1].toUpperCase();
+  const degrees = parseInt(m[2], 10);
+  const minutes = parseFloat(m[3]);
+  if (minutes >= 60) return null;
+  const decimal = degrees + minutes / 60;
+  if (hemi === 'S' || hemi === 'W') return -decimal;
+  return decimal;
+}
+
+/**
+ * Format signed decimal degrees as an ADIF "Location" value (`XDDD MM.MMM`).
+ * `axis` selects the hemisphere letters: 'lat' → N/S, 'lon' → E/W. Degrees are
+ * zero-padded to three digits and minutes to `MM.MMM`, matching the ADIF grammar
+ * strict readers expect.
+ */
+export function decimalToAdifCoord(decimal: number, axis: 'lat' | 'lon'): string {
+  const isLat = axis === 'lat';
+  const hemisphere = decimal < 0 ? (isLat ? 'S' : 'W') : isLat ? 'N' : 'E';
+  const abs = Math.abs(decimal);
+  const degrees = Math.floor(abs);
+  const minutes = (abs - degrees) * 60;
+  return `${hemisphere}${String(degrees).padStart(3, '0')} ${minutes.toFixed(3).padStart(6, '0')}`;
 }
 
 function adifDateTimeToUtc(adifDate: string, adifTime: string): Date | null {
@@ -332,8 +381,10 @@ export function generateAdif(contacts: AdifExportContact[]): string {
     record += adifField('qth', contact.qth);
     record += adifField('gridsquare', contact.grid_locator ? contact.grid_locator.toUpperCase() : contact.grid_locator);
     record += adifField('notes', contact.notes);
-    record += adifField('lat_n', contact.latitude);
-    record += adifField('lon_w', contact.longitude);
+    // ADIF LAT/LON are `XDDD MM.MMM` strings, not decimal degrees. Emit them via
+    // the formatter (guarding null but allowing an exact 0 = equator/meridian).
+    record += adifField('lat', contact.latitude != null ? decimalToAdifCoord(contact.latitude, 'lat') : null);
+    record += adifField('lon', contact.longitude != null ? decimalToAdifCoord(contact.longitude, 'lon') : null);
 
     // Station ("my") information.
     record += adifField('station_callsign', contact.station_callsign ? contact.station_callsign.toUpperCase() : contact.station_callsign);

--- a/tests/adif-generate.spec.ts
+++ b/tests/adif-generate.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from '@playwright/test';
 import {
   adifField,
+  adifCoordToDecimal,
+  decimalToAdifCoord,
   generateAdif,
   parseAdifRecords,
   type AdifExportContact,
@@ -35,6 +37,52 @@ test.describe('adifField', () => {
   test('serializes numbers', () => {
     expect(adifField('dxcc', 291)).toBe('<dxcc:3>291\n');
     expect(adifField('freq', 14.074)).toBe('<freq:6>14.074\n');
+  });
+});
+
+// The ADIF "Location" data type is `XDDD MM.MMM` (hemisphere letter, 3-digit
+// degrees, minutes) — NOT decimal degrees. Nextlog previously round-tripped raw
+// decimals through non-standard lat_n/lon_w fields, so coordinates never
+// interoperated with LoTW/TQSL, Cloudlog or N1MM. These guard the conversion.
+test.describe('adifCoordToDecimal', () => {
+  test('parses the four hemispheres into signed decimal degrees', () => {
+    expect(adifCoordToDecimal('N040 26.500')).toBeCloseTo(40.44167, 4);
+    expect(adifCoordToDecimal('S040 26.500')).toBeCloseTo(-40.44167, 4);
+    expect(adifCoordToDecimal('E073 58.000')).toBeCloseTo(73.96667, 4);
+    expect(adifCoordToDecimal('W073 58.000')).toBeCloseTo(-73.96667, 4);
+  });
+
+  test('handles the origin and is case/whitespace tolerant', () => {
+    expect(adifCoordToDecimal('N000 00.000')).toBe(0);
+    expect(adifCoordToDecimal('  w000 30.000  ')).toBeCloseTo(-0.5, 6);
+  });
+
+  test('rejects malformed values', () => {
+    expect(adifCoordToDecimal('40.44')).toBeNull(); // plain decimal, no hemisphere
+    expect(adifCoordToDecimal('X040 26.500')).toBeNull(); // bad hemisphere letter
+    expect(adifCoordToDecimal('N040 60.000')).toBeNull(); // minutes must be < 60
+    expect(adifCoordToDecimal('')).toBeNull();
+  });
+});
+
+test.describe('decimalToAdifCoord', () => {
+  test('formats signed decimals with padded degrees/minutes', () => {
+    expect(decimalToAdifCoord(40.44167, 'lat')).toBe('N040 26.500');
+    expect(decimalToAdifCoord(-40.44167, 'lat')).toBe('S040 26.500');
+    expect(decimalToAdifCoord(-73.96667, 'lon')).toBe('W073 58.000');
+    expect(decimalToAdifCoord(0, 'lat')).toBe('N000 00.000');
+  });
+
+  test('round-trips decimal → ADIF → decimal within a metre', () => {
+    for (const [dec, axis] of [
+      [51.4779, 'lat'],
+      [-0.0015, 'lon'],
+      [-33.8688, 'lat'],
+      [151.2093, 'lon'],
+    ] as const) {
+      const parsed = adifCoordToDecimal(decimalToAdifCoord(dec, axis));
+      expect(parsed).toBeCloseTo(dec, 4);
+    }
   });
 });
 
@@ -150,6 +198,27 @@ test.describe('generateAdif', () => {
     expect(adif).toContain('<band_rx:4>70CM');
     expect(adif).toContain('<freq_rx:7>435.795');
     expect(adif).toContain('<iota:6>NA-001');
+  });
+
+  // Coordinates must export as standard ADIF LAT/LON in `XDDD MM.MMM` form so
+  // other loggers and mapping tools can read them — not the old non-standard
+  // decimal lat_n/lon_w fields no external software recognized.
+  test('emits latitude/longitude as standard ADIF LAT/LON', () => {
+    const adif = generateAdif([
+      baseContact({ latitude: 40.44167, longitude: -73.96667 }),
+    ]);
+
+    expect(adif).toContain('<lat:11>N040 26.500');
+    expect(adif).toContain('<lon:11>W073 58.000');
+    // The legacy non-standard field names must be gone.
+    expect(adif).not.toContain('lat_n');
+    expect(adif).not.toContain('lon_w');
+  });
+
+  test('omits LAT/LON when a contact has no coordinates', () => {
+    const adif = generateAdif([baseContact()]);
+    expect(adif).not.toContain('<lat:');
+    expect(adif).not.toContain('<lon:');
   });
 
   test('round-trips satellite/IOTA fields back through the parser', () => {


### PR DESCRIPTION
## Problem

Nextlog round-tripped contact coordinates through **non-standard `lat_n` / `lon_w` fields carrying raw decimal degrees**. This is broken interop on two fronts:

- **No other software uses those field names.** LoTW/TQSL, Cloudlog, N1MM, and GridTracker all read/write the standard ADIF `LAT` / `LON` fields. Importing an ADIF file from any of them left `latitude`/`longitude` null, so those contacts never got coordinates (breaking mapping).
- **Decimal degrees aren't valid ADIF anyway.** The ADIF "Location" data type is `XDDD MM.MMM` (hemisphere letter, 3-digit degrees, decimal minutes), e.g. `N040 26.500`. Nextlog's exported coordinates were unreadable by external tools even where the field name matched.

## Solution

Emit and parse the spec-correct `LAT` / `LON` fields, converting to/from signed decimal degrees:

- New pure helper `adifCoordToDecimal('N040 26.500')` → `40.44167` (S/W hemispheres negative; rejects malformed input and minutes ≥ 60).
- New pure helper `decimalToAdifCoord(40.44167, 'lat')` → `'N040 26.500'` (zero-padded degrees/minutes, correct hemisphere per axis).
- **Export** now writes `<lat:11>N040 26.500` / `<lon:11>W073 58.000` instead of the old decimal `lat_n`/`lon_w`. An exact `0` (equator / prime meridian) is now emitted too.
- **Import** reads standard `lat`/`lon`, and still accepts the legacy `lat_n`/`lon_w` decimal fields as a fallback so files previously exported by Nextlog keep round-tripping (backwards compatible).

No schema change — `contacts.latitude`/`longitude` remain decimal degrees; only the ADIF wire format changed.

## Testing

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run build` — compiles successfully
- `npx playwright test tests/adif-generate.spec.ts` — 19 passed, including new coverage:
  - `adifCoordToDecimal`: four hemispheres, origin, case/whitespace tolerance, malformed-input rejection
  - `decimalToAdifCoord`: padded formatting + decimal→ADIF→decimal round-trip within ~1 m
  - `generateAdif`: emits standard `LAT`/`LON`, drops the legacy field names, omits coordinates when absent

## Future follow-up

- The DB-touching import path (`insertAdifRecord`) is covered indirectly via the pure helpers; a full integration test would need the Playwright DB fixture.
- The `LAT`/`LON` precision is `MM.MMM` (~1 m), matching ADIF's canonical example — sufficient for grid-derived coordinates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)