### PR TITLE
fix(adif): read 4-digit HHMM QSO times as HH:MM:00 on import

### DIFF
--- a/src/lib/adif.ts
+++ b/src/lib/adif.ts
@@ -248,11 +248,21 @@ export function decimalToAdifCoord(decimal: number, axis: 'lat' | 'lon'): string
   return `${hemisphere}${String(degrees).padStart(3, '0')} ${minutes.toFixed(3).padStart(6, '0')}`;
 }
 
-function adifDateTimeToUtc(adifDate: string, adifTime: string): Date | null {
+/**
+ * Convert an ADIF QSO_DATE (`YYYYMMDD`) + TIME_ON/TIME_OFF into a UTC Date, or
+ * null if either is unparseable. The ADIF Time type is `HHMMSS` *or* `HHMM`
+ * (seconds omitted), so a 4-digit time is read as `HH:MM:00` — the missing
+ * seconds are appended, not right-aligned. Reading `2359` as `00:23:59` would
+ * silently shift the QSO to the wrong time of day (and, near midnight, the
+ * wrong date).
+ */
+export function adifDateTimeToUtc(adifDate: string, adifTime: string): Date | null {
   try {
-    // ADIF date format: YYYYMMDD, time format: HHMMSS or HHMM (pad)
+    // ADIF date format: YYYYMMDD, time format: HHMMSS or HHMM. A 4-digit HHMM
+    // time omits the seconds, so pad on the *right* (append "00" seconds) — not
+    // the left, which would misread 1230 as 00:12:30 instead of 12:30:00.
     const dateStr = adifDate.padStart(8, '0');
-    const timeStr = adifTime.padStart(6, '0');
+    const timeStr = adifTime.length >= 6 ? adifTime.slice(0, 6) : adifTime.padEnd(6, '0');
 
     const year = parseInt(dateStr.substring(0, 4));
     const month = parseInt(dateStr.substring(4, 6)) - 1;

--- a/tests/adif-datetime.spec.ts
+++ b/tests/adif-datetime.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+import { adifDateTimeToUtc } from '@/lib/adif';
+
+// Pure-function tests for ADIF QSO_DATE + TIME_ON → UTC conversion. The ADIF
+// Time type is HHMMSS *or* HHMM (seconds omitted). A 4-digit time must be read
+// as HHMM:00 — appending "00" seconds — not as a right-aligned HHMMSS, which
+// would silently shift the QSO to the wrong time of day (2359 → 00:23:59).
+
+test.describe('adifDateTimeToUtc', () => {
+  test('reads a full HHMMSS time', () => {
+    const d = adifDateTimeToUtc('20231231', '235900');
+    expect(d?.toISOString()).toBe('2023-12-31T23:59:00.000Z');
+  });
+
+  test('reads a 4-digit HHMM time as HH:MM:00', () => {
+    const d = adifDateTimeToUtc('20231231', '2359');
+    expect(d?.toISOString()).toBe('2023-12-31T23:59:00.000Z');
+  });
+
+  test('reads noon from a 4-digit time', () => {
+    const d = adifDateTimeToUtc('20240101', '1200');
+    expect(d?.toISOString()).toBe('2024-01-01T12:00:00.000Z');
+  });
+
+  test('reads midnight from a 4-digit time', () => {
+    const d = adifDateTimeToUtc('20240101', '0000');
+    expect(d?.toISOString()).toBe('2024-01-01T00:00:00.000Z');
+  });
+
+  test('returns null for an unparseable date', () => {
+    expect(adifDateTimeToUtc('notadate', '1200')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

ADIF's `Time` type is `HHMMSS` **or** `HHMM` (seconds omitted). When a logger emits a 4-digit `TIME_ON`/`TIME_OFF`, Nextlog imported it at the wrong time of day.

`adifDateTimeToUtc` left-padded the time to six digits:

```ts
const timeStr = adifTime.padStart(6, '0'); // "2359" -> "002359"
```

So `2359` (23:59) was parsed as `00:23:59`, `1230` (12:30) as `00:12:30`, and so on. Every QSO imported from a logger that omits seconds landed at the wrong time — and a late-evening contact near midnight could even shift onto the wrong calendar day.

4-digit times are valid ADIF (and appear in this repo's own parser fixtures, e.g. `<time_on:4>2359`), so this silently corrupted real imports. WSJT-X-style `HHMMSS` logs were unaffected, which is likely why it went unnoticed.

## Solution

Pad on the **right** (append `"00"` seconds) instead of the left, and clip over-long values to six digits:

```ts
const timeStr = adifTime.length >= 6 ? adifTime.slice(0, 6) : adifTime.padEnd(6, '0');
```

`adifDateTimeToUtc` is now exported (it was module-private) so it can be unit-tested as a pure function, and carries a doc comment explaining the HHMM/HHMMSS rule.

The QRZ ADIF path (`src/lib/qrz.ts`) already parses HHMM correctly (it slices left-to-right with seconds defaulting to 0), so no change was needed there.

## Testing

- New `tests/adif-datetime.spec.ts`: covers `HHMMSS`, `HHMM` at noon/midnight/23:59, and an unparseable date returning `null`. Confirmed the two HHMM cases failed before the fix and pass after.
- `npx playwright test adif-datetime adif-parse adif-generate` — 28 passing.
- `npm run typecheck`, `npm run lint`, `npm run build` — all clean.

## Future follow-up

None required. The fix is isolated to the one conversion helper.