### PR TITLE
fix(search): keep SQL placeholders aligned when QSL status + DXCC filters combine

### DIFF
--- a/src/app/api/contacts/search/route.ts
+++ b/src/app/api/contacts/search/route.ts
@@ -2,19 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { verifyToken } from '@/lib/auth';
 import { query } from '@/lib/db';
 import { generateAdif, type AdifExportContact } from '@/lib/adif';
-
-interface SearchFilters {
-  callsign?: string;
-  name?: string;
-  qth?: string;
-  mode?: string;
-  band?: string;
-  gridLocator?: string;
-  startDate?: string;
-  endDate?: string;
-  qslStatus?: string;
-  dxcc?: string;
-}
+import { buildContactSearchQuery } from '@/lib/contact-search';
 
 export async function GET(request: NextRequest) {
   try {
@@ -31,8 +19,11 @@ export async function GET(request: NextRequest) {
 
     const userId = typeof user.userId === 'string' ? parseInt(user.userId, 10) : user.userId;
 
-    // Extract search filters
-    const filters: SearchFilters = {
+    // Build the parameterized WHERE clause from the query-string filters. The
+    // builder numbers placeholders off the params array so a predicate-only
+    // filter (QSL status) can't shift a later value-bound filter (DXCC) onto a
+    // nonexistent `$N` — the bug that used to 500 confirmed-status + DXCC searches.
+    const { whereClause, params: queryParams } = buildContactSearchQuery(userId, {
       callsign: searchParams.get('callsign') || undefined,
       name: searchParams.get('name') || undefined,
       qth: searchParams.get('qth') || undefined,
@@ -43,68 +34,7 @@ export async function GET(request: NextRequest) {
       endDate: searchParams.get('endDate') || undefined,
       qslStatus: searchParams.get('qslStatus') || undefined,
       dxcc: searchParams.get('dxcc') || undefined,
-    };
-
-    // Build the WHERE clause and parameters
-    const whereConditions: string[] = ['user_id = $1'];
-    const queryParams: (string | number)[] = [userId];
-    let paramCount = 1;
-
-    // Add search conditions
-    Object.entries(filters).forEach(([key, value]) => {
-      if (value && value.trim() !== '' && value !== 'all') {
-        paramCount++;
-        switch (key) {
-          case 'callsign':
-            whereConditions.push(`UPPER(callsign) LIKE UPPER($${paramCount})`);
-            queryParams.push(`%${value}%`);
-            break;
-          case 'name':
-            whereConditions.push(`UPPER(name) LIKE UPPER($${paramCount})`);
-            queryParams.push(`%${value}%`);
-            break;
-          case 'qth':
-            whereConditions.push(`UPPER(qth) LIKE UPPER($${paramCount})`);
-            queryParams.push(`%${value}%`);
-            break;
-          case 'mode':
-            whereConditions.push(`UPPER(mode) = UPPER($${paramCount})`);
-            queryParams.push(value);
-            break;
-          case 'band':
-            whereConditions.push(`UPPER(band) = UPPER($${paramCount})`);
-            queryParams.push(value);
-            break;
-          case 'gridLocator':
-            whereConditions.push(`UPPER(grid_locator) LIKE UPPER($${paramCount})`);
-            queryParams.push(`%${value}%`);
-            break;
-          case 'startDate':
-            whereConditions.push(`DATE(datetime) >= $${paramCount}`);
-            queryParams.push(value);
-            break;
-          case 'endDate':
-            whereConditions.push(`DATE(datetime) <= $${paramCount}`);
-            queryParams.push(value);
-            break;
-          case 'qslStatus':
-            // For now, we'll implement basic QSL status filtering
-            // This can be expanded when QSL fields are added to the schema
-            if (value === 'confirmed') {
-              whereConditions.push(`confirmed = true`);
-            } else if (value === 'not_confirmed') {
-              whereConditions.push(`(confirmed = false OR confirmed IS NULL)`);
-            }
-            break;
-          case 'dxcc':
-            whereConditions.push(`dxcc = $${paramCount}`);
-            queryParams.push(parseInt(value));
-            break;
-        }
-      }
     });
-
-    const whereClause = whereConditions.join(' AND ');
 
     if (isExport) {
       // Export all matching contacts as ADIF

--- a/src/lib/contact-search.ts
+++ b/src/lib/contact-search.ts
@@ -1,0 +1,98 @@
+// WHERE-clause builder for the contact search (GET /api/contacts/search).
+//
+// Kept free of server-only imports (no `pg`, no db pool) so it can be unit
+// tested directly, like @/lib/grid and @/lib/bands. The route feeds the result
+// straight into `query(sql, params)`.
+//
+// Placeholders ($2, $3, …) are numbered off the length of the `params` array as
+// each value is pushed, so they can never drift out of step with the values.
+// The subtle bug this prevents: a predicate-only filter (`qslStatus` adds
+// `confirmed = true` with no bound value) must not advance the placeholder
+// counter — otherwise a later value-bound filter (`dxcc`) references a `$N`
+// that has no matching parameter, 500-ing the COUNT query and mis-binding the
+// paginated one.
+
+export interface ContactSearchFilters {
+  callsign?: string;
+  name?: string;
+  qth?: string;
+  mode?: string;
+  band?: string;
+  gridLocator?: string;
+  startDate?: string;
+  endDate?: string;
+  qslStatus?: string;
+  dxcc?: string;
+}
+
+export interface ContactSearchQuery {
+  /** The full WHERE clause, always anchored on `user_id = $1`. */
+  whereClause: string;
+  /** Bound parameter values, index N-1 corresponding to placeholder `$N`. */
+  params: (string | number)[];
+}
+
+/**
+ * Build the parameterized WHERE clause + bound values for a contact search.
+ * Blank, whitespace-only, and the `all` sentinel are treated as "no filter".
+ */
+export function buildContactSearchQuery(
+  userId: number,
+  filters: ContactSearchFilters,
+): ContactSearchQuery {
+  const conditions: string[] = ['user_id = $1'];
+  const params: (string | number)[] = [userId];
+
+  // Push a value and return its 1-based placeholder index, keeping the two in
+  // lockstep no matter how many predicate-only filters precede it.
+  const bind = (value: string | number): number => params.push(value);
+
+  for (const [key, raw] of Object.entries(filters)) {
+    const value = raw?.trim();
+    if (!value || value === 'all') continue;
+
+    switch (key) {
+      case 'callsign':
+        conditions.push(`UPPER(callsign) LIKE UPPER($${bind(`%${value}%`)})`);
+        break;
+      case 'name':
+        conditions.push(`UPPER(name) LIKE UPPER($${bind(`%${value}%`)})`);
+        break;
+      case 'qth':
+        conditions.push(`UPPER(qth) LIKE UPPER($${bind(`%${value}%`)})`);
+        break;
+      case 'mode':
+        conditions.push(`UPPER(mode) = UPPER($${bind(value)})`);
+        break;
+      case 'band':
+        conditions.push(`UPPER(band) = UPPER($${bind(value)})`);
+        break;
+      case 'gridLocator':
+        conditions.push(`UPPER(grid_locator) LIKE UPPER($${bind(`%${value}%`)})`);
+        break;
+      case 'startDate':
+        conditions.push(`DATE(datetime) >= $${bind(value)}`);
+        break;
+      case 'endDate':
+        conditions.push(`DATE(datetime) <= $${bind(value)}`);
+        break;
+      case 'qslStatus':
+        // Predicate-only: adds SQL but binds no value, so it must NOT call bind().
+        if (value === 'confirmed') {
+          conditions.push('confirmed = true');
+        } else if (value === 'not_confirmed') {
+          conditions.push('(confirmed = false OR confirmed IS NULL)');
+        }
+        break;
+      case 'dxcc': {
+        const dxcc = parseInt(value, 10);
+        if (!Number.isNaN(dxcc)) {
+          conditions.push(`dxcc = $${bind(dxcc)}`);
+        }
+        break;
+      }
+    }
+  }
+
+  return { whereClause: conditions.join(' AND '), params };
+}

--- a/tests/contact-search.spec.ts
+++ b/tests/contact-search.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from '@playwright/test';
+import { buildContactSearchQuery } from '@/lib/contact-search';
+
+// Pure-function tests for the contact-search WHERE-clause builder. This is the
+// shared query builder behind GET /api/contacts/search — it turns the filter
+// set into a parameterized WHERE clause plus its bound values. No DB needed.
+//
+// The regression these guard: placeholders ($2, $3, …) must stay in lockstep
+// with the params array. A filter like `qslStatus` adds a SQL predicate but no
+// bound value; the previous code advanced a shared counter for *every* filter,
+// so any predicate-only filter shifted the numbering of every later filter —
+// combining "confirmed" with a DXCC entity produced a `$N` with no matching
+// value (500 on the COUNT query) or a dxcc compared against the LIMIT value.
+
+test.describe('buildContactSearchQuery', () => {
+  test('always begins with the mandatory user_id predicate', () => {
+    const { whereClause, params } = buildContactSearchQuery(7, {});
+    expect(whereClause).toBe('user_id = $1');
+    expect(params).toEqual([7]);
+  });
+
+  test('LIKE filters use case-insensitive contains matching', () => {
+    const { whereClause, params } = buildContactSearchQuery(1, { callsign: 'w1aw' });
+    expect(whereClause).toBe('user_id = $1 AND UPPER(callsign) LIKE UPPER($2)');
+    expect(params).toEqual([1, '%w1aw%']);
+  });
+
+  test('mode and band match exactly (case-insensitive)', () => {
+    const { whereClause, params } = buildContactSearchQuery(1, { mode: 'ft8', band: '20m' });
+    expect(whereClause).toBe(
+      'user_id = $1 AND UPPER(mode) = UPPER($2) AND UPPER(band) = UPPER($3)'
+    );
+    expect(params).toEqual([1, 'ft8', '20m']);
+  });
+
+  test('date range filters compare on the calendar date', () => {
+    const { whereClause, params } = buildContactSearchQuery(1, {
+      startDate: '2024-01-01',
+      endDate: '2024-12-31',
+    });
+    expect(whereClause).toBe(
+      'user_id = $1 AND DATE(datetime) >= $2 AND DATE(datetime) <= $3'
+    );
+    expect(params).toEqual([1, '2024-01-01', '2024-12-31']);
+  });
+
+  test('dxcc is bound as an integer', () => {
+    const { whereClause, params } = buildContactSearchQuery(1, { dxcc: '291' });
+    expect(whereClause).toBe('user_id = $1 AND dxcc = $2');
+    expect(params).toEqual([1, 291]);
+  });
+
+  test('qsl status adds a predicate but no bound parameter', () => {
+    const confirmed = buildContactSearchQuery(1, { qslStatus: 'confirmed' });
+    expect(confirmed.whereClause).toBe('user_id = $1 AND confirmed = true');
+    expect(confirmed.params).toEqual([1]);
+
+    const notConfirmed = buildContactSearchQuery(1, { qslStatus: 'not_confirmed' });
+    expect(notConfirmed.whereClause).toBe(
+      'user_id = $1 AND (confirmed = false OR confirmed IS NULL)'
+    );
+    expect(notConfirmed.params).toEqual([1]);
+  });
+
+  test('an unrecognized qsl status contributes nothing', () => {
+    const { whereClause, params } = buildContactSearchQuery(1, { qslStatus: 'pending' });
+    expect(whereClause).toBe('user_id = $1');
+    expect(params).toEqual([1]);
+  });
+
+  // The core regression: a predicate-only filter (qslStatus) sitting *before*
+  // a value-bound filter (dxcc) must not shift dxcc's placeholder off its value.
+  test('qsl status combined with dxcc keeps placeholders aligned with params', () => {
+    const { whereClause, params } = buildContactSearchQuery(1, {
+      qslStatus: 'confirmed',
+      dxcc: '291',
+    });
+    expect(whereClause).toBe('user_id = $1 AND confirmed = true AND dxcc = $2');
+    expect(params).toEqual([1, 291]);
+
+    // Every `$N` referenced in the clause must have a corresponding param.
+    const referenced = [...whereClause.matchAll(/\$(\d+)/g)].map(m => Number(m[1]));
+    expect(Math.max(...referenced)).toBe(params.length);
+  });
+
+  test('blank, whitespace, and "all" sentinel values are ignored', () => {
+    const { whereClause, params } = buildContactSearchQuery(1, {
+      callsign: '',
+      name: '   ',
+      mode: 'all',
+      band: '40m',
+    });
+    expect(whereClause).toBe('user_id = $1 AND UPPER(band) = UPPER($2)');
+    expect(params).toEqual([1, '40m']);
+  });
+
+  test('a full filter set numbers every bound placeholder sequentially', () => {
+    const { whereClause, params } = buildContactSearchQuery(42, {
+      callsign: 'dl',
+      name: 'hans',
+      qth: 'berlin',
+      mode: 'cw',
+      band: '15m',
+      gridLocator: 'jo',
+      startDate: '2024-06-01',
+      endDate: '2024-06-30',
+      qslStatus: 'confirmed',
+      dxcc: '230',
+    });
+
+    // 10 filters supplied, but qslStatus binds no value → 9 bound params + userId.
+    expect(params).toEqual([
+      42, '%dl%', '%hans%', '%berlin%', 'cw', '15m', '%jo%',
+      '2024-06-01', '2024-06-30', 230,
+    ]);
+
+    const referenced = [...whereClause.matchAll(/\$(\d+)/g)].map(m => Number(m[1]));
+    // Placeholders must be exactly $1..$params.length with no gaps or overshoot.
+    expect(referenced).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(Math.max(...referenced)).toBe(params.length);
+  });
+});


### PR DESCRIPTION
## Problem

The advanced contact search (`GET /api/contacts/search`, backing the `/search` page) breaks whenever an operator combines a **QSL status** filter with a **DXCC entity** filter.

The route built its parameterized `WHERE` clause with a single `paramCount` counter that was bumped once per active filter:

```ts
paramCount++;
switch (key) { ... }
```

But the `qslStatus` branch adds a SQL predicate (`confirmed = true` / `(confirmed = false OR confirmed IS NULL)`) **without pushing a bound value**. That desyncs `paramCount` from the `queryParams` array. Because `dxcc` is applied after `qslStatus`, selecting e.g. "Confirmed" **and** a DXCC entity produced a `$N` placeholder with no matching parameter:

- **Count query** (`query(countSql, queryParams)`) referenced `$3` while only 2 params were supplied → Postgres `there is no parameter $3` → the whole request 500s with "Internal server error".
- **Paginated query** collided the `dxcc` placeholder with the `LIMIT` placeholder, silently filtering `dxcc = <limit value>` (e.g. `dxcc = 20`) and returning wrong rows.

The search UI sends both fields together, so any DX-focused search scoped by confirmation status was affected.

## Solution

Extracted the WHERE-clause construction into a pure, server-import-free module `src/lib/contact-search.ts` (same pattern as `@/lib/grid` / `@/lib/bands`, so it's unit-testable without a DB). Placeholders are now numbered off the length of the `params` array *as each value is pushed* — a predicate-only filter simply doesn't push, so it can never shift a later filter's placeholder.

The route now delegates to `buildContactSearchQuery(userId, filters)`, dropping ~55 lines of inline query-building. Behavior is otherwise identical (also added a small guard so a non-numeric `dxcc` is ignored rather than bound as `NaN`).

## Testing

- **New unit tests** (`tests/contact-search.spec.ts`, 10 cases) covering each filter, the `all`/blank sentinels, the predicate-only QSL-status branch, and specifically the **QSL-status + DXCC alignment regression** (asserts every `$N` in the clause has a matching param).
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run build` — succeeds
- Full pure-function suite (grid/bands/adif/frequency/contact-search) — 58 passed

## Backwards compatibility

No API surface change — same query params, same response shape. Purely a correctness fix plus test coverage.

## Future follow-up

- Per `CLAUDE.md`, this route's query params (`gridLocator`, `startDate`, `endDate`, `qslStatus`) are still camelCase — a known drifting surface deferred to a later snake_case sweep. Left untouched here to keep the change focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)