### PR TITLE
fix(search): repair QSL-status filter that referenced a nonexistent `confirmed` column

### DIFF
--- a/src/lib/contact-search.ts
+++ b/src/lib/contact-search.ts
@@ -6,8 +6,8 @@
 //
 // Placeholders ($2, $3, …) are numbered off the length of the `params` array as
 // each value is pushed, so they can never drift out of step with the values.
-// The subtle bug this prevents: a predicate-only filter (`qslStatus` adds
-// `confirmed = true` with no bound value) must not advance the placeholder
+// The subtle bug this prevents: a predicate-only filter (`qslStatus` adds a QSL
+// confirmation expression with no bound value) must not advance the placeholder
 // counter — otherwise a later value-bound filter (`dxcc`) references a `$N`
 // that has no matching parameter, 500-ing the COUNT query and mis-binding the
 // paginated one.
@@ -24,6 +24,24 @@ export interface ContactSearchFilters {
   qslStatus?: string;
   dxcc?: string;
 }
+
+/**
+ * SQL boolean expression that is true when a QSO has been confirmed by any QSL
+ * source — LoTW (either the boolean sync flag or an ADIF-style 'Y'), QRZ, paper,
+ * or eQSL. There is no `confirmed` column; this mirrors the canonical definition
+ * in Contact.countConfirmedByUserId (the dashboard "QSL Confirmed" stat) so the
+ * search filter and the stat card agree on what "confirmed" means.
+ *
+ * Each term is wrapped so the whole expression is a plain boolean that is never
+ * NULL — that lets it be negated cleanly (`NOT ...`) for the "not confirmed"
+ * filter without a NULL QSL column silently dropping an unconfirmed row.
+ */
+export const CONFIRMED_QSL_SQL =
+  "(COALESCE(qsl_lotw, false) " +
+  "OR COALESCE(lotw_qsl_rcvd, '') = 'Y' " +
+  "OR COALESCE(qrz_qsl_rcvd, '') = 'Y' " +
+  "OR COALESCE(qsl_rcvd, '') = 'Y' " +
+  "OR COALESCE(eqsl_qsl_rcvd, '') = 'Y')";
 
 export interface ContactSearchQuery {
   /** The full WHERE clause, always anchored on `user_id = $1`. */
@@ -78,10 +96,13 @@ export function buildContactSearchQuery(
         break;
       case 'qslStatus':
         // Predicate-only: adds SQL but binds no value, so it must NOT call bind().
+        // There is no `confirmed` column — expand to the real QSL-source check
+        // (see CONFIRMED_QSL_SQL). The old `confirmed = true` 500'd every
+        // QSL-status search with "column confirmed does not exist".
         if (value === 'confirmed') {
-          conditions.push('confirmed = true');
+          conditions.push(CONFIRMED_QSL_SQL);
         } else if (value === 'not_confirmed') {
-          conditions.push('(confirmed = false OR confirmed IS NULL)');
+          conditions.push(`NOT ${CONFIRMED_QSL_SQL}`);
         }
         break;
       case 'dxcc': {

--- a/tests/contact-search.spec.ts
+++ b/tests/contact-search.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { buildContactSearchQuery } from '@/lib/contact-search';
+import { buildContactSearchQuery, CONFIRMED_QSL_SQL } from '@/lib/contact-search';
 
 // Pure-function tests for the contact-search WHERE-clause builder. This is the
 // shared query builder behind GET /api/contacts/search — it turns the filter
@@ -50,16 +50,34 @@ test.describe('buildContactSearchQuery', () => {
     expect(params).toEqual([1, 291]);
   });
 
+  // There is no `confirmed` column — a QSO is "confirmed" when any QSL source
+  // (LoTW, QRZ, paper, eQSL) confirms it, mirroring Contact.countConfirmedByUserId.
+  // The filter emits that real expression rather than a nonexistent column, and
+  // the "not confirmed" case negates it (NULL-safe, so unconfirmed rows with NULL
+  // QSL fields still match).
   test('qsl status adds a predicate but no bound parameter', () => {
     const confirmed = buildContactSearchQuery(1, { qslStatus: 'confirmed' });
-    expect(confirmed.whereClause).toBe('user_id = $1 AND confirmed = true');
+    expect(confirmed.whereClause).toBe(`user_id = $1 AND ${CONFIRMED_QSL_SQL}`);
     expect(confirmed.params).toEqual([1]);
 
     const notConfirmed = buildContactSearchQuery(1, { qslStatus: 'not_confirmed' });
-    expect(notConfirmed.whereClause).toBe(
-      'user_id = $1 AND (confirmed = false OR confirmed IS NULL)'
-    );
+    expect(notConfirmed.whereClause).toBe(`user_id = $1 AND NOT ${CONFIRMED_QSL_SQL}`);
     expect(notConfirmed.params).toEqual([1]);
+  });
+
+  // The confirmed expression must reference only real columns and never a bare
+  // `confirmed` (the column that never existed and 500'd every QSL-status search).
+  test('the confirmed predicate references real columns, not a `confirmed` column', () => {
+    expect(CONFIRMED_QSL_SQL).not.toMatch(/\bconfirmed\b/);
+    for (const col of [
+      'qsl_lotw',
+      'lotw_qsl_rcvd',
+      'qrz_qsl_rcvd',
+      'qsl_rcvd',
+      'eqsl_qsl_rcvd',
+    ]) {
+      expect(CONFIRMED_QSL_SQL).toContain(col);
+    }
   });
 
   test('an unrecognized qsl status contributes nothing', () => {
@@ -75,7 +93,7 @@ test.describe('buildContactSearchQuery', () => {
       qslStatus: 'confirmed',
       dxcc: '291',
     });
-    expect(whereClause).toBe('user_id = $1 AND confirmed = true AND dxcc = $2');
+    expect(whereClause).toBe(`user_id = $1 AND ${CONFIRMED_QSL_SQL} AND dxcc = $2`);
     expect(params).toEqual([1, 291]);
 
     // Every `$N` referenced in the clause must have a corresponding param.


### PR DESCRIPTION
## Problem

The contact-search filter for **QSL Status** was completely broken. The WHERE-clause builder (`src/lib/contact-search.ts`) emitted SQL referencing a `confirmed` column:

```sql
-- qslStatus=confirmed
... AND confirmed = true
-- qslStatus=not_confirmed
... AND (confirmed = false OR confirmed IS NULL)
```

But **no `confirmed` column exists** anywhere in the schema (`drizzle/schema.ts`), the baseline migration, or the models. Every search with **QSL Status = Confirmed** or **Not Confirmed** (from `/search`) therefore failed with Postgres `column "confirmed" does not exist` → the API returned 500 and the search page showed an error.

The recent placeholder-alignment fix (#236) corrected how `$N` parameters line up when QSL status combines with DXCC, but the underlying predicate still pointed at a phantom column, so the filter could never actually run.

## Solution

Expand the QSL-status predicate to the **real** confirmation expression, mirroring the canonical definition already used by `Contact.countConfirmedByUserId` (the dashboard "QSL Confirmed" stat card) — a QSO is confirmed when any QSL source confirms it (LoTW sync flag or `'Y'`, QRZ, paper, eQSL):

```sql
(COALESCE(qsl_lotw, false)
 OR COALESCE(lotw_qsl_rcvd, '') = 'Y'
 OR COALESCE(qrz_qsl_rcvd, '') = 'Y'
 OR COALESCE(qsl_rcvd,      '') = 'Y'
 OR COALESCE(eqsl_qsl_rcvd, '') = 'Y')
```

This is exported as `CONFIRMED_QSL_SQL` so the search filter and the stat card share one source of truth. Every term is `COALESCE`-wrapped to a plain boolean that is **never NULL**, so the "Not Confirmed" filter is a clean `NOT (...)` — a NULL QSL column no longer silently drops an unconfirmed row from the results (the classic three-valued-logic trap of negating a NULL predicate).

No schema change; the predicate-only nature (binds no `$N` value) is preserved, so the #236 placeholder alignment still holds.

## Testing

- Updated `tests/contact-search.spec.ts` to assert the emitted predicate is the real QSL-source expression (not a bare `confirmed` column) for both `confirmed` and `not_confirmed`, plus a guard test that the expression references only real columns.
- `npx playwright test contact-search.spec.ts` → **11 passed**
- `npm run typecheck` → clean
- `npm run lint` → clean
- `npm run build` → compiled successfully

## Follow-up

- The vestigial `confirmed?: boolean` field on the search page's `Contact` interface is never populated by `SELECT *` (there's no such column); it could be removed or replaced with a computed value in a later cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)