### PR TITLE
fix(search): make the "QSL Pending" filter actually filter

### DIFF
--- a/src/lib/contact-search.ts
+++ b/src/lib/contact-search.ts
@@ -43,6 +43,20 @@ export const CONFIRMED_QSL_SQL =
   "OR COALESCE(qsl_rcvd, '') = 'Y' " +
   "OR COALESCE(eqsl_qsl_rcvd, '') = 'Y')";
 
+/**
+ * SQL boolean expression that is true when a QSL has been sent, requested, or
+ * queued on any channel — paper, eQSL, LoTW, or QRZ. Per the ADIF QSL-status
+ * enumeration these fields hold 'Y' (sent), 'R' (requested), or 'Q' (queued);
+ * 'N'/'I' and NULL mean nothing is outstanding. Like CONFIRMED_QSL_SQL it is
+ * COALESCE-wrapped so the whole expression is a plain, never-NULL boolean and
+ * composes cleanly inside the "pending" predicate.
+ */
+export const SENT_QSL_SQL =
+  "(COALESCE(qsl_sent, '') IN ('Y', 'R', 'Q') " +
+  "OR COALESCE(eqsl_qsl_sent, '') IN ('Y', 'R', 'Q') " +
+  "OR COALESCE(lotw_qsl_sent, '') IN ('Y', 'R', 'Q') " +
+  "OR COALESCE(qrz_qsl_sent, '') IN ('Y', 'R', 'Q'))";
+
 export interface ContactSearchQuery {
   /** The full WHERE clause, always anchored on `user_id = $1`. */
   whereClause: string;
@@ -103,6 +117,12 @@ export function buildContactSearchQuery(
           conditions.push(CONFIRMED_QSL_SQL);
         } else if (value === 'not_confirmed') {
           conditions.push(`NOT ${CONFIRMED_QSL_SQL}`);
+        } else if (value === 'pending') {
+          // "Awaiting a reply": a QSL was sent/requested/queued on some channel
+          // but no source has confirmed it yet. The search UI offers this option
+          // (QSL Status → Pending); before this case it fell through and matched
+          // every contact. A strict subset of `not_confirmed`.
+          conditions.push(`(${SENT_QSL_SQL} AND NOT ${CONFIRMED_QSL_SQL})`);
         }
         break;
       case 'dxcc': {

--- a/tests/contact-search.spec.ts
+++ b/tests/contact-search.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { buildContactSearchQuery, CONFIRMED_QSL_SQL } from '@/lib/contact-search';
+import { buildContactSearchQuery, CONFIRMED_QSL_SQL, SENT_QSL_SQL } from '@/lib/contact-search';
 
 // Pure-function tests for the contact-search WHERE-clause builder. This is the
 // shared query builder behind GET /api/contacts/search — it turns the filter
@@ -65,6 +65,29 @@ test.describe('buildContactSearchQuery', () => {
     expect(notConfirmed.params).toEqual([1]);
   });
 
+  // "Pending" is offered in the search UI's QSL-status dropdown. It must mean a
+  // QSO where a QSL was sent/requested on at least one channel but no source has
+  // confirmed it yet — i.e. awaiting a reply. The predicate is the sent-side
+  // expression AND-ed with the negated confirmed expression; still no bound value.
+  // Regression: 'pending' used to fall through the switch and contribute nothing,
+  // so the UI filter silently returned every contact.
+  test('qsl status "pending" filters sent-but-not-confirmed QSOs, with no bound parameter', () => {
+    const pending = buildContactSearchQuery(1, { qslStatus: 'pending' });
+    expect(pending.whereClause).toBe(
+      `user_id = $1 AND (${SENT_QSL_SQL} AND NOT ${CONFIRMED_QSL_SQL})`
+    );
+    expect(pending.params).toEqual([1]);
+  });
+
+  // The sent expression must reference only real "sent" columns (Y/R/Q states),
+  // never a received column or a bare `confirmed`.
+  test('the sent predicate references the real qsl-sent columns', () => {
+    expect(SENT_QSL_SQL).not.toMatch(/\bconfirmed\b/);
+    for (const col of ['qsl_sent', 'eqsl_qsl_sent', 'lotw_qsl_sent', 'qrz_qsl_sent']) {
+      expect(SENT_QSL_SQL).toContain(col);
+    }
+  });
+
   // The confirmed expression must reference only real columns and never a bare
   // `confirmed` (the column that never existed and 500'd every QSL-status search).
   test('the confirmed predicate references real columns, not a `confirmed` column', () => {
@@ -81,7 +104,7 @@ test.describe('buildContactSearchQuery', () => {
   });
 
   test('an unrecognized qsl status contributes nothing', () => {
-    const { whereClause, params } = buildContactSearchQuery(1, { qslStatus: 'pending' });
+    const { whereClause, params } = buildContactSearchQuery(1, { qslStatus: 'bogus' });
     expect(whereClause).toBe('user_id = $1');
     expect(params).toEqual([1]);
   });


### PR DESCRIPTION
## Problem

The contact search page exposes a **QSL Status → Pending** option in its Advanced Filters dropdown (`src/app/search/page.tsx`), and the active-filter chip labels it "QSL Pending". But the shared query builder behind `GET /api/contacts/search` (`src/lib/contact-search.ts`) only handled `confirmed` and `not_confirmed`. The `pending` value fell straight through the `switch` and added **no** predicate.

Result: selecting "Pending" was a silent no-op — the search returned **every** contact rather than the ones awaiting a QSL reply. The existing test even codified the wrong behavior (`'pending'` "contributes nothing"), so the gap between UI and backend went unnoticed.

## Solution

- Add a `SENT_QSL_SQL` expression: true when a QSL has been **sent, requested, or queued** on any channel — paper (`qsl_sent`), eQSL (`eqsl_qsl_sent`), LoTW (`lotw_qsl_sent`), or QRZ (`qrz_qsl_sent`) — per the ADIF QSL-status enumeration (`Y`/`R`/`Q`). It's `COALESCE`-wrapped to a never-NULL boolean, mirroring the existing `CONFIRMED_QSL_SQL`, so it composes cleanly.
- Wire `qslStatus = 'pending'` to `(SENT_QSL_SQL AND NOT CONFIRMED_QSL_SQL)` — i.e. you've done your part but no source has confirmed yet. This is a strict subset of `not_confirmed`.
- Like the other QSL-status cases it is **predicate-only** — it binds no parameter, so the `$N` placeholder numbering (the subject of #236/#237) stays intact when combined with value-bound filters like DXCC.

No UI, schema, or API-shape changes — the frontend already sends `qslStatus=pending`; it just now does something.

## Testing

- Updated `tests/contact-search.spec.ts`:
  - New test asserting `pending` emits `(SENT_QSL_SQL AND NOT CONFIRMED_QSL_SQL)` with no bound param.
  - New test asserting `SENT_QSL_SQL` references only the real `*_qsl_sent` columns (never a received column or a bare `confirmed`).
  - Retargeted the "unrecognized status contributes nothing" test to a genuinely bogus value, since `pending` is now recognized.
- `npx playwright test contact-search` — 13 passed.
- `npm run typecheck`, `npm run lint`, `npm run build` — all clean.

## Follow-up (out of scope)

- The search page's QSL-status dropdown could surface distinct "sent-not-confirmed" vs "never-actioned" states now that the backend distinguishes them, but the current three-way (confirmed / pending / not confirmed) is coherent as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)