### PR TITLE
feat(search): add notes/comment text search filter

### DIFF
--- a/src/app/api/contacts/search/route.ts
+++ b/src/app/api/contacts/search/route.ts
@@ -27,6 +27,7 @@ export async function GET(request: NextRequest) {
       callsign: searchParams.get('callsign') || undefined,
       name: searchParams.get('name') || undefined,
       qth: searchParams.get('qth') || undefined,
+      notes: searchParams.get('notes') || undefined,
       mode: searchParams.get('mode') || undefined,
       band: searchParams.get('band') || undefined,
       gridLocator: searchParams.get('gridLocator') || undefined,

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -56,6 +56,7 @@ interface SearchFilters {
   callsign: string;
   name: string;
   qth: string;
+  notes: string;
   mode: string;
   band: string;
   gridLocator: string;
@@ -112,6 +113,15 @@ const getActiveFilterChips = (filters: SearchFilters, dxccEntities: DXCCEntity[]
     });
   }
   
+  if (filters.notes.trim()) {
+    chips.push({
+      key: 'notes',
+      label: 'Notes',
+      value: filters.notes,
+      displayValue: filters.notes
+    });
+  }
+
   if (filters.qth.trim()) {
     chips.push({
       key: 'qth',
@@ -260,6 +270,7 @@ export default function SearchPage() {
     callsign: '',
     name: '',
     qth: '',
+    notes: '',
     mode: 'all',
     band: 'all',
     gridLocator: '',
@@ -442,6 +453,7 @@ export default function SearchPage() {
       callsign: '',
       name: '',
       qth: '',
+      notes: '',
       mode: 'all',
       band: 'all',
       gridLocator: '',
@@ -856,7 +868,18 @@ export default function SearchPage() {
                   <hr className="border-border" />
                   <div className="space-y-4">
                     <Label className="text-base font-medium">Advanced Filters</Label>
-                    
+
+                    {/* Notes / Comments */}
+                    <div className="space-y-2">
+                      <Label htmlFor="notes">Notes</Label>
+                      <Input
+                        id="notes"
+                        placeholder="e.g., POTA K-1234, contest exchange, QSL note"
+                        value={filters.notes}
+                        onChange={(e) => handleFilterChange('notes', e.target.value)}
+                      />
+                    </div>
+
                     {/* Date Range */}
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                       <div className="space-y-2">

--- a/src/lib/contact-search.ts
+++ b/src/lib/contact-search.ts
@@ -16,6 +16,7 @@ export interface ContactSearchFilters {
   callsign?: string;
   name?: string;
   qth?: string;
+  notes?: string;
   mode?: string;
   band?: string;
   gridLocator?: string;
@@ -92,6 +93,12 @@ export function buildContactSearchQuery(
         break;
       case 'qth':
         conditions.push(`UPPER(qth) LIKE UPPER($${bind(`%${value}%`)})`);
+        break;
+      case 'notes':
+        // Free-text remarks — POTA/SOTA references, contest exchanges, personal
+        // notes. Contains-match like the other text fields so operators can find
+        // a QSO by whatever they jotted down.
+        conditions.push(`UPPER(notes) LIKE UPPER($${bind(`%${value}%`)})`);
         break;
       case 'mode':
         conditions.push(`UPPER(mode) = UPPER($${bind(value)})`);

--- a/tests/contact-search.spec.ts
+++ b/tests/contact-search.spec.ts
@@ -25,6 +25,12 @@ test.describe('buildContactSearchQuery', () => {
     expect(params).toEqual([1, '%w1aw%']);
   });
 
+  test('notes/comment text is matched with case-insensitive contains', () => {
+    const { whereClause, params } = buildContactSearchQuery(1, { notes: 'POTA K-1234' });
+    expect(whereClause).toBe('user_id = $1 AND UPPER(notes) LIKE UPPER($2)');
+    expect(params).toEqual([1, '%POTA K-1234%']);
+  });
+
   test('mode and band match exactly (case-insensitive)', () => {
     const { whereClause, params } = buildContactSearchQuery(1, { mode: 'ft8', band: '20m' });
     expect(whereClause).toBe(
@@ -140,6 +146,7 @@ test.describe('buildContactSearchQuery', () => {
       callsign: 'dl',
       name: 'hans',
       qth: 'berlin',
+      notes: 'field day',
       mode: 'cw',
       band: '15m',
       gridLocator: 'jo',
@@ -149,15 +156,15 @@ test.describe('buildContactSearchQuery', () => {
       dxcc: '230',
     });
 
-    // 10 filters supplied, but qslStatus binds no value → 9 bound params + userId.
+    // 11 filters supplied, but qslStatus binds no value → 10 bound params + userId.
     expect(params).toEqual([
-      42, '%dl%', '%hans%', '%berlin%', 'cw', '15m', '%jo%',
+      42, '%dl%', '%hans%', '%berlin%', '%field day%', 'cw', '15m', '%jo%',
       '2024-06-01', '2024-06-30', 230,
     ]);
 
     const referenced = [...whereClause.matchAll(/\$(\d+)/g)].map(m => Number(m[1]));
     // Placeholders must be exactly $1..$params.length with no gaps or overshoot.
-    expect(referenced).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(referenced).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
     expect(Math.max(...referenced)).toBe(params.length);
   });
 });


### PR DESCRIPTION
## Problem

The contact search lets operators filter by callsign, name, QTH, grid, band, mode, date range, DXCC entity, and QSL status — but **not by the notes/comment text** on a QSO. That's where operators record the things they most often want to find a contact by later: POTA/SOTA park references (`K-1234`, `W7A/...`), contest exchanges, special-event details, and personal reminders. Without notes search, finding "that POTA activation from last month" means paging through results by hand.

## Solution

Adds a `notes` filter, wired end-to-end and matching the existing text-field behavior (case-insensitive `LIKE '%value%'` contains match):

- **`src/lib/contact-search.ts`** — new `notes?` field on `ContactSearchFilters` and a `case 'notes'` in the WHERE-clause builder. The predicate binds through the same `bind()` helper, so placeholder numbering stays in lockstep with the params array (the invariant the existing tests guard).
- **`src/app/api/contacts/search/route.ts`** — reads the `notes` query param and passes it to the builder.
- **`src/app/search/page.tsx`** — a **Notes** input in the Advanced Filters section, plus the matching `SearchFilters` field, initial/clear-all defaults, and an active-filter chip. Chip removal already routes through the default (`''`) case, so no handler change was needed.

The filter participates in the existing debounced search and in ADIF export of search results (both build their query string from the same filter object), so exporting a notes-filtered result set works automatically.

## Testing

- `tests/contact-search.spec.ts` — added a focused test asserting `notes` produces `UPPER(notes) LIKE UPPER($2)` with `['%POTA K-1234%']`, and extended the full-filter-set test to include `notes` and verify placeholder/param alignment stays correct with the extra bound value. **All 14 builder tests pass.**
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run build` — compiles successfully

## Backwards compatibility

Purely additive. The `notes` param is optional; existing searches, saved links, and the `/api/contacts/search` contract are unchanged when it's absent.

## Future follow-up

- The search query params (`gridLocator`, `startDate`, `notes`, …) remain camelCase, consistent with the existing surface that CLAUDE.md flags for a later snake_case sweep. This PR intentionally matches the current convention rather than expanding that drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)