### PR TITLE
fix(search): let operators filter by every band they can log (add 2200M/630M/4M/1.25M/33CM/13CM)

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -21,6 +21,7 @@ import LotwSyncIndicator from '@/components/LotwSyncIndicator';
 import QRZSyncIndicator from '@/components/QRZSyncIndicator';
 import DynamicContactMap from '@/components/DynamicContactMap';
 import { useUser } from '@/contexts/UserContext';
+import { AMATEUR_BANDS } from '@/lib/bands';
 
 interface Contact {
   id: number;
@@ -81,7 +82,13 @@ interface PaginationInfo {
 }
 
 const MODES = ['AM', 'FM', 'FT8', 'MFSK', 'RTTY', 'SSB', 'CW', 'FT4', 'PSK31', 'DMR', 'DSTAR', 'YSF'];
-const BANDS = ['2m', '6m', '10m', '12m', '15m', '17m', '20m', '30m', '40m', '60m', '80m', '160m', '70cm', '23cm'];
+// Band options come from the canonical band plan (@/lib/bands) — the same list
+// the logging forms (new-contact, QuickLogCard) store — so every band an
+// operator can log is also filterable here. The previous hard-coded lowercase
+// list had drifted and silently omitted 2200M, 630M, 4M, 1.25M, 33CM and 13CM,
+// making QSOs on those bands unsearchable. Matching is case-insensitive on the
+// server (UPPER(band) = UPPER($n)), so the uppercase values match stored data.
+const BANDS = AMATEUR_BANDS;
 
 interface FilterChip {
   key: keyof SearchFilters;

--- a/tests/bands.spec.ts
+++ b/tests/bands.spec.ts
@@ -46,4 +46,24 @@ test.describe('bands module', () => {
     expect(frequencyToBand(100.0)).toBe('OTHER');
     expect(AMATEUR_BANDS).not.toContain('OTHER');
   });
+
+  test('covers every band the search filter must offer, including the six the old list dropped', () => {
+    // The contact-search band dropdown sources its options from AMATEUR_BANDS
+    // (the same list the logging forms store), so an operator can always filter
+    // for a band they were able to log. It previously hard-coded a shorter
+    // lowercase list that omitted these six — a 4M or 630M QSO could be logged
+    // from a one-click pill but never filtered back out in search.
+    const previouslyUnfilterable = ['2200M', '630M', '4M', '1.25M', '33CM', '13CM'];
+    for (const band of previouslyUnfilterable) {
+      expect(AMATEUR_BANDS).toContain(band);
+    }
+    // And the bands the old list did have are still present, so nothing regressed.
+    const legacySearchBands = [
+      '2M', '6M', '10M', '12M', '15M', '17M', '20M', '30M', '40M', '60M', '80M',
+      '160M', '70CM', '23CM',
+    ];
+    for (const band of legacySearchBands) {
+      expect(AMATEUR_BANDS).toContain(band);
+    }
+  });
 });


### PR DESCRIPTION
## Problem

The **Search → Band** filter hard-coded its own band list that had drifted out of sync with the rest of the app. The logging forms (`new-contact`, `QuickLogCard`) present one-click band pills sourced from the canonical band plan (`AMATEUR_BANDS` in `@/lib/bands`), and the ADIF importer derives bands from the same plan — so a QSO can be logged/imported on any of **20 bands**. But the search dropdown only offered **14**, silently omitting:

- **2200M**, **630M** (LF/MF digital)
- **4M**
- **1.25M** (222 MHz)
- **33CM** (902 MHz), **13CM** (2.3 GHz)

Result: an operator could log a contact on, say, 4M or 630M with a single click, then find it impossible to filter for that band in Search — the option simply wasn't in the list. The hard-coded copy was also lowercase (`'20m'`) while the app stores/derives uppercase (`'20M'`), a classic drift trap.

## Solution

Source the Search band dropdown from the single source of truth, `AMATEUR_BANDS`, the same list the logging forms use. This removes the drift by construction — the search filter can no longer fall behind the band plan.

Server-side matching is already case-insensitive (`UPPER(band) = UPPER($n)` in `buildContactSearchQuery`), so switching the option values from lowercase to the canonical uppercase form matches existing stored data without any migration.

One line of behavior, plus an explanatory comment:

```ts
const BANDS = AMATEUR_BANDS;
```

## Testing

- Extended `tests/bands.spec.ts` with a test asserting the canonical band plan covers **every** band the search filter must offer — explicitly including the six previously-unfilterable bands and the legacy set (nothing regressed). This guards against the band plan ever being trimmed in a way that would re-break search coverage.
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run build` — succeeds (`/search` compiles)
- `npx playwright test tests/bands.spec.ts` — 5/5 pass

## Scope / follow-up

- Kept strictly to the band filter (one problem, done well).
- The Search **mode** dropdown is hard-coded the same way and has similar drift (e.g. JS8/FST4 submodes stored as modes since #240 aren't offered). There is no canonical mode-list module to source from yet; introducing one and wiring the mode filter to it is a natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)