### PR TITLE
feat(logging): let operators log every supported mode (JS8/FST4/Q65/…), not just 8

### DIFF
--- a/src/app/new-contact/page.tsx
+++ b/src/app/new-contact/page.tsx
@@ -37,6 +37,7 @@ import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
 import { frequencyToBand, AMATEUR_BANDS } from '@/lib/bands';
+import { AMATEUR_MODES, defaultRstForMode } from '@/lib/modes';
 import { gridToLatLon, distanceKm, bearingDeg, compassPoint, kmToMiles } from '@/lib/grid';
 
 void _PageHeader;
@@ -61,7 +62,7 @@ interface PreviousContact {
   notes?: string;
 }
 
-const MODES = ['SSB', 'CW', 'FT8', 'FT4', 'RTTY', 'PSK31', 'AM', 'FM'] as const;
+const MODES = AMATEUR_MODES;
 const BAND_PILLS = AMATEUR_BANDS;
 
 // QRZ XML license-class codes — used to give the chip a human-readable label.
@@ -381,20 +382,8 @@ export default function NewContactPage() {
   };
 
   const handleSelectMode = (value: string) => {
-    setFormData((prev) => {
-      const next = { ...prev, mode: value };
-      if (value === 'CW') {
-        next.rst_sent = '599';
-        next.rst_received = '599';
-      } else if (['SSB', 'FM', 'AM'].includes(value)) {
-        next.rst_sent = '59';
-        next.rst_received = '59';
-      } else if (['FT8', 'FT4', 'PSK31', 'RTTY', 'MFSK', 'OLIVIA', 'CONTESTIA'].includes(value)) {
-        next.rst_sent = '-10';
-        next.rst_received = '-10';
-      }
-      return next;
-    });
+    const rst = defaultRstForMode(value);
+    setFormData((prev) => ({ ...prev, mode: value, rst_sent: rst, rst_received: rst }));
   };
 
   const handleSelectBand = (value: string) => {

--- a/src/components/QuickLogCard.tsx
+++ b/src/components/QuickLogCard.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/components/ui/select';
 import { cn } from '@/lib/utils';
 import { frequencyToBand, AMATEUR_BANDS } from '@/lib/bands';
+import { AMATEUR_MODES, defaultRstForMode } from '@/lib/modes';
 
 interface Station {
   id: number;
@@ -39,14 +40,8 @@ interface LookupResult {
   error?: string;
 }
 
-const MODES = ['SSB', 'CW', 'FT8', 'FT4', 'RTTY', 'PSK31', 'AM', 'FM'] as const;
+const MODES = AMATEUR_MODES;
 const BANDS = AMATEUR_BANDS;
-
-function defaultRstForMode(mode: string): string {
-  if (mode === 'CW') return '599';
-  if (['FT8', 'FT4', 'PSK31', 'RTTY', 'MFSK', 'OLIVIA', 'CONTESTIA'].includes(mode)) return '-10';
-  return '59';
-}
 
 function formatUtcClock(d: Date): string {
   const hh = String(d.getUTCHours()).padStart(2, '0');

--- a/src/lib/modes.ts
+++ b/src/lib/modes.ts
@@ -38,3 +38,27 @@ export const AMATEUR_MODES = [
 ] as const;
 
 export type AmateurMode = (typeof AMATEUR_MODES)[number];
+
+// Modes whose signal report is conventionally a dB SNR (e.g. "-10") rather than
+// an RST. Both logging forms carried their own copy of this list; keeping it
+// here as the single source of truth stops the two from drifting apart (and from
+// falling behind AMATEUR_MODES) as new digital modes become loggable.
+//
+// The WSJT-X / weak-signal family (FT8, FT4, JS8, FST4, JT65, JT9, Q65, MSK144)
+// genuinely reports dB. The keyboard PSK/RTTY/MFSK/Olivia/Contestia group is
+// grouped here to preserve the default Nextlog has always applied to those menu
+// entries — not because RTTY is a dB mode.
+const DB_REPORT_MODES = new Set<string>([
+  'FT8', 'FT4', 'JS8', 'FST4', 'JT65', 'JT9', 'Q65', 'MSK144',
+  'PSK31', 'PSK63', 'RTTY', 'MFSK', 'OLIVIA', 'CONTESTIA',
+]);
+
+// The signal report a logging form should pre-fill when an operator picks `mode`.
+// CW takes RST with a tone digit (599); dB-report digital modes take -10; every
+// other mode (phone, digital voice, image, packet) takes a 59 RS(T).
+export function defaultRstForMode(mode: string): string {
+  const m = mode.trim().toUpperCase();
+  if (m === 'CW') return '599';
+  if (DB_REPORT_MODES.has(m)) return '-10';
+  return '59';
+}

--- a/tests/modes.spec.ts
+++ b/tests/modes.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { AMATEUR_MODES } from '@/lib/modes';
+import { AMATEUR_MODES, defaultRstForMode } from '@/lib/modes';
 
 // The mode list is the canonical set of operating modes Nextlog can store, and
 // the single source of truth the contact-search mode dropdown draws from. These
@@ -52,5 +52,56 @@ test.describe('modes module', () => {
   test('leads with the everyday phone and CW modes so the dropdown is fast to scan', () => {
     // Operators reach for SSB/CW/FT8 far more than Olivia; keep them at the top.
     expect(AMATEUR_MODES.slice(0, 4)).toEqual(['SSB', 'CW', 'FT8', 'FT4']);
+  });
+});
+
+test.describe('defaultRstForMode', () => {
+  test('CW gets a 599 signal report', () => {
+    expect(defaultRstForMode('CW')).toBe('599');
+  });
+
+  test('phone modes get a 59 signal report', () => {
+    for (const mode of ['SSB', 'AM', 'FM']) {
+      expect(defaultRstForMode(mode)).toBe('59');
+    }
+  });
+
+  test('digital dB-report modes default to -10', () => {
+    // WSJT-X / weak-signal families report a dB SNR, and Nextlog has always
+    // defaulted its PSK/RTTY/MFSK/Olivia/Contestia menu entries the same way.
+    const dbModes = [
+      'FT8', 'FT4', 'JS8', 'FST4', 'JT65', 'JT9', 'Q65', 'MSK144',
+      'PSK31', 'PSK63', 'RTTY', 'MFSK', 'OLIVIA', 'CONTESTIA',
+    ];
+    for (const mode of dbModes) {
+      expect(defaultRstForMode(mode)).toBe('-10');
+    }
+  });
+
+  test('preserves the exact classification the logging forms used before centralizing', () => {
+    // The two logging forms each carried their own copy of this heuristic; the
+    // shared helper must not change the default for any mode they both handled.
+    expect(defaultRstForMode('CW')).toBe('599');
+    for (const mode of ['FT8', 'FT4', 'PSK31', 'RTTY', 'MFSK', 'OLIVIA', 'CONTESTIA']) {
+      expect(defaultRstForMode(mode)).toBe('-10');
+    }
+  });
+
+  test('digital-voice and image modes fall back to 59', () => {
+    for (const mode of ['DMR', 'DSTAR', 'C4FM', 'YSF', 'M17', 'FREEDV', 'SSTV', 'PACKET', 'ATV']) {
+      expect(defaultRstForMode(mode)).toBe('59');
+    }
+  });
+
+  test('is case-insensitive', () => {
+    expect(defaultRstForMode('cw')).toBe('599');
+    expect(defaultRstForMode('ft8')).toBe('-10');
+    expect(defaultRstForMode('ssb')).toBe('59');
+  });
+
+  test('returns a default for every canonical mode', () => {
+    for (const mode of AMATEUR_MODES) {
+      expect(['59', '599', '-10']).toContain(defaultRstForMode(mode));
+    }
   });
 });


### PR DESCRIPTION
## Problem

Both logging forms — the dashboard **Quick Log** card and the full **New Contact** page — hard-coded the same 8-entry mode menu:

```
SSB · CW · FT8 · FT4 · RTTY · PSK31 · AM · FM
```

Meanwhile the rest of the app has moved past that list:

- **Search** now offers the full canonical mode list (#242) — JS8, FST4, JT65, JT9, Q65, MSK144, PSK63, Olivia, Contestia, the digital-voice modes, etc.
- **ADIF import** promotes a WSJT-X/fldigi `SUBMODE` to the stored mode (#240), so a JS8 or Q65 run lands in the log as `JS8`/`Q65`.

The result was a drift: an operator could **import** and **filter** those modes, but could not **log** one directly. Working a JS8 or Q65 station from the dashboard meant picking the wrong mode and fixing it after the fact. This is exactly the class of hard-coded-list-drift the search filters were fixed for in #241/#242.

## Solution

- Both forms now source their mode menu from the canonical `AMATEUR_MODES` (`src/lib/modes.ts`) — precisely the way they already source their band menu from `AMATEUR_BANDS`. Every mode the log can store is now loggable, and the list can never fall behind import/search again.
- The per-mode RST default (599 for CW, a dB-style `-10` for the digital families, `59` otherwise) was **duplicated** across the two forms with two subtly different, incomplete copies. It's now a single `defaultRstForMode(mode)` helper in the canonical modes module. The classification is preserved exactly for every mode both forms already handled, and extended to the newly loggable digital modes (JS8, FST4, JT65, JT9, Q65, MSK144, PSK63).

No new options were removed — all 8 legacy modes remain, in the same lead position (SSB/CW/FT8/FT4 stay at the top of the list). The menus are ordered common-first, so the everyday phone/CW modes are still the first thing an operator sees.

### Behavior note
On the New Contact page, selecting a mode that fell outside the old three `if` branches (e.g. `DMR`) previously left the RST untouched; it now resets to `59`, matching what the Quick Log card already did. This makes the two forms consistent and is a sensible default for digital-voice/image modes.

## Testing

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run build` — succeeds
- `npx playwright test tests/modes.spec.ts` — 12 passed, including new `defaultRstForMode` coverage (CW→599, phone→59, dB modes→-10, digital-voice/image→59, case-insensitivity, backward-compat with the pre-centralization classification, and a default for every canonical mode).

## Future follow-up

- The dB-style `-10` default currently also covers RTTY/PSK/MFSK/Olivia/Contestia. That's preserved from the prior behavior (not necessarily conventionally correct — RTTY/PSK operators often send RST), and could be revisited separately if desired.