### PR TITLE
fix(logging): don't overwrite a contact's NULL power with 0 on edit

### DIFF
--- a/src/components/EditContactDialog.tsx
+++ b/src/components/EditContactDialog.tsx
@@ -248,10 +248,16 @@ export default function EditContactDialog({ contact, isOpen, onClose, onSave, on
         body: JSON.stringify({
           ...formData,
           datetime: formData.datetime ? new Date(formData.datetime).toISOString() : undefined,
-          // Blank power clears the field (null), not an empty string a numeric
-          // column would reject.
+          // Blank/absent power clears the field (null), not an empty string a
+          // numeric column would reject. `== null` catches both a cleared input
+          // (undefined/'') and a contact loaded with no power (JSON null) — the
+          // latter must stay null, not become Number(null) === 0, which would
+          // otherwise overwrite NULL with 0 and defeat the export's
+          // COALESCE(c.tx_pwr, s.power_watts) station-power fallback.
           tx_pwr:
-            formData.tx_pwr === undefined || (formData.tx_pwr as unknown) === ''
+            formData.tx_pwr == null ||
+            (formData.tx_pwr as unknown) === '' ||
+            Number.isNaN(Number(formData.tx_pwr))
               ? null
               : Number(formData.tx_pwr),
         }),


### PR DESCRIPTION
## Problem

Follow-up to #244 (per-QSO transmit power). A code-review pass caught a data-corruption bug in the edit dialog that merged before the fix could be appended.

When you open an existing QSO that was logged **without** power, `contacts.tx_pwr` is `NULL` and arrives in the edit dialog as JSON `null`. The submit-time normalization only mapped `undefined` and `''` to `null`:

```ts
tx_pwr:
  formData.tx_pwr === undefined || (formData.tx_pwr as unknown) === ''
    ? null
    : Number(formData.tx_pwr),
```

`null` matched neither guard, so it fell through to `Number(null)` — which is **`0`**, not `null`. Saving any unrelated edit (e.g. a note) on such a QSO silently rewrote the column from `NULL` to `0`. That also defeats the export's `COALESCE(c.tx_pwr, s.power_watts)` fallback introduced in #244: the QSO now exports `0` instead of the station's default power (and `adifField` omits a `0`, so `TX_PWR` vanishes from the export entirely). The empty input box hides the corruption from the operator.

## Fix

Treat null / undefined / blank / NaN uniformly as "clear to NULL":

```ts
tx_pwr:
  formData.tx_pwr == null ||
  (formData.tx_pwr as unknown) === '' ||
  Number.isNaN(Number(formData.tx_pwr))
    ? null
    : Number(formData.tx_pwr),
```

`== null` catches both a cleared input and a contact loaded with no power, so a NULL power stays NULL through an edit. A real value (including `0`) still round-trips.

## Testing

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run build` — compiled successfully (verified before push)
- DB-free pure-function specs — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)