### PR TITLE
fix(grid): accept 8-char extended locators in the logging form & stations API

### DIFF
--- a/src/app/api/stations/[id]/route.ts
+++ b/src/app/api/stations/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { Station } from '@/models/Station';
 import { verifyToken } from '@/lib/auth';
 import { encryptString } from '@/lib/lotw';
+import { gridLocatorError } from '@/lib/grid';
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -61,14 +62,13 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
       data.callsign = data.callsign.toUpperCase();
     }
 
-    // Validate grid locator if provided
+    // Validate grid locator if provided. Uses the canonical validator so an
+    // 8-char extended locator (the on-air grid a VHF/microwave op transmits from,
+    // and the origin of the logging-form distance readout) saves rather than 400s.
     if (data.grid_locator) {
-      const gridRegex = /^[A-R]{2}[0-9]{2}([A-X]{2})?$/;
-      if (!gridRegex.test(data.grid_locator.toUpperCase())) {
-        return NextResponse.json(
-          { error: 'Invalid grid locator format' },
-          { status: 400 }
-        );
+      const gridError = gridLocatorError(data.grid_locator);
+      if (gridError) {
+        return NextResponse.json({ error: gridError }, { status: 400 });
       }
       data.grid_locator = data.grid_locator.toUpperCase();
     }

--- a/src/app/api/stations/route.ts
+++ b/src/app/api/stations/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { Station } from '@/models/Station';
 import { verifyToken } from '@/lib/auth';
+import { gridLocatorError } from '@/lib/grid';
 
 export async function GET(request: NextRequest) {
   try {
@@ -47,14 +48,13 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Validate grid locator if provided
+    // Validate grid locator if provided. Uses the canonical validator so an
+    // 8-char extended locator (the on-air grid a VHF/microwave op transmits from,
+    // and the origin of the logging-form distance readout) saves rather than 400s.
     if (data.grid_locator) {
-      const gridRegex = /^[A-R]{2}[0-9]{2}([A-X]{2})?$/;
-      if (!gridRegex.test(data.grid_locator.toUpperCase())) {
-        return NextResponse.json(
-          { error: 'Invalid grid locator format' },
-          { status: 400 }
-        );
+      const gridError = gridLocatorError(data.grid_locator);
+      if (gridError) {
+        return NextResponse.json({ error: gridError }, { status: 400 });
       }
     }
 

--- a/src/app/new-contact/page.tsx
+++ b/src/app/new-contact/page.tsx
@@ -40,6 +40,7 @@ import { frequencyToBand, AMATEUR_BANDS } from '@/lib/bands';
 import { AMATEUR_MODES, defaultRstForMode } from '@/lib/modes';
 import {
   gridToLatLon,
+  gridLocatorError,
   distanceKm,
   bearingDeg,
   compassPoint,
@@ -349,12 +350,9 @@ export default function NewContactPage() {
       ? null
       : 'Invalid callsign format';
   };
-  const validateGridLocator = (grid: string): string | null => {
-    if (!grid.trim()) return null;
-    return /^[A-R]{2}[0-9]{2}([A-X]{2})?$/i.test(grid)
-      ? null
-      : 'Invalid grid locator format (e.g., FN31pr)';
-  };
+  // Delegates to the canonical validator in @/lib/grid so the logging form and
+  // the stations API stay in lockstep and both accept 8-char extended locators.
+  const validateGridLocator = (grid: string): string | null => gridLocatorError(grid);
   const validateFrequency = (frequency: string): string | null => {
     if (!frequency.trim()) return null;
     const freq = parseFloat(frequency);

--- a/src/lib/grid.ts
+++ b/src/lib/grid.ts
@@ -23,6 +23,19 @@ export function isValidGrid(grid: string): boolean {
   return GRID_RE.test(grid.trim().toUpperCase());
 }
 
+// Validation helper for form/API inputs where the grid is optional: returns null
+// when the field is blank OR a well-formed locator, and a human-readable error
+// message otherwise. Centralizing this on isValidGrid keeps the logging form and
+// the stations API from re-deriving their own regex — which is how they drifted
+// behind the 8-char (extended) locators the rest of the app already accepts,
+// silently rejecting a valid VHF/microwave grid on save.
+export function gridLocatorError(grid: string): string | null {
+  if (!grid.trim()) return null;
+  return isValidGrid(grid)
+    ? null
+    : 'Invalid grid locator format (e.g., FN31, FN31pr, or FN31pr55)';
+}
+
 // Convert a Maidenhead locator to the latitude/longitude of the *center* of the
 // square (4-char), subsquare (6-char), or extended square (8-char). Returns
 // null for anything that isn't a valid locator. Centering matches

--- a/tests/grid.spec.ts
+++ b/tests/grid.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import {
   isValidGrid,
+  gridLocatorError,
   gridToLatLon,
   distanceKm,
   bearingDeg,
@@ -38,6 +39,28 @@ test.describe('isValidGrid', () => {
     expect(isValidGrid('FN31pr5')).toBe(false); // odd length (extended pair)
     expect(isValidGrid('FN31prAB')).toBe(false); // extended square must be digits
     expect(isValidGrid('FN3155')).toBe(false); // can't skip the subsquare level
+  });
+});
+
+test.describe('gridLocatorError', () => {
+  test('treats blank/whitespace as no error (grid is optional)', () => {
+    expect(gridLocatorError('')).toBeNull();
+    expect(gridLocatorError('   ')).toBeNull();
+  });
+
+  test('accepts 4-, 6-, and 8-character locators like isValidGrid', () => {
+    expect(gridLocatorError('FN31')).toBeNull();
+    expect(gridLocatorError('FN31pr')).toBeNull();
+    // The regression this guards: an 8-char extended locator is valid app-wide
+    // (isValidGrid, gridToLatLon) and must not be rejected by form/API checks.
+    expect(gridLocatorError('FN31pr55')).toBeNull();
+    expect(gridLocatorError(' jn58td99 ')).toBeNull();
+  });
+
+  test('returns a helpful message for a malformed locator', () => {
+    expect(gridLocatorError('nope')).toContain('Invalid grid locator');
+    expect(gridLocatorError('FN31p')).toContain('Invalid grid locator');
+    expect(gridLocatorError('FN3155')).toContain('Invalid grid locator');
   });
 });
 


### PR DESCRIPTION
## Problem

Commit #246 taught the app to understand **8-character (extended) Maidenhead locators** — `isValidGrid` and `gridToLatLon` in `src/lib/grid.ts` accept and geolocate them — and #248 uses the *on-air station's grid* as the origin for the live distance/bearing readout. VHF/UHF/microwave and satellite operators log 8-char locators for the extra precision.

But three input validators never got the memo and kept their own **4/6-character-only** regex (`/^[A-R]{2}[0-9]{2}([A-X]{2})?$/`):

- the `new-contact` logging form's inline `validateGridLocator`
- `POST /api/stations`
- `PUT /api/stations/[id]`

So the app that computes a distance *from* an 8-char grid wouldn't let you **enter** one:

- Typing `FN31pr55` into the logging form's grid field showed **"Invalid grid locator format"** and blocked the save.
- Saving a station with an 8-char grid — the very locator used as the distance origin — returned **HTTP 400**.

This is the same "local list/regex drifts behind the canonical `src/lib` module" class of bug fixed for band and mode filters in #241/#242.

## Solution

Add one canonical helper to the grid module and route all three call sites through it:

```ts
// src/lib/grid.ts
export function gridLocatorError(grid: string): string | null {
  if (!grid.trim()) return null;           // grid is optional everywhere it's validated
  return isValidGrid(grid) ? null : 'Invalid grid locator format (e.g., FN31, FN31pr, or FN31pr55)';
}
```

Because it delegates to `isValidGrid`, the logging form and the stations API can no longer drift from the rest of the app. No schema or response-shape changes; validation is only *loosened* to accept locators the app already stores and geolocates, so it's fully backwards compatible.

## Testing

- Added unit coverage for `gridLocatorError` (blank/whitespace → no error; 4/6/8-char → valid; malformed → message) in `tests/grid.spec.ts`.
- `npx playwright test grid.spec.ts` — **30/30 pass**.
- `npm run typecheck`, `npm run lint`, `npm run build` — all clean.

## Future follow-up

- `POST /api/stations` and `PUT /api/stations/[id]` share a fair amount of validation logic (callsign, grid, power, zones) that could be extracted into one shared validator; out of scope here.
- The client station create/edit forms (`/stations/new`, `/stations/[id]/edit`) rely on server-side validation for the grid; adding matching inline feedback via `gridLocatorError` would be a nice parity touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)